### PR TITLE
Optimize Pomodoro controller timing

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,8 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-07-30 | Hardened Pomodoro expiry against malformed deadlines, action/deadline races, and transient post-expiry refresh failures | `docs/recurrences-and-pomodoro.md` | `src/lib/pomodoro/engine.ts`, `src/app/use-pomodoro-controller.ts`, Pomodoro tests |
+| 2026-07-30 | Reworked Pomodoro timing so display ticks are local to timer views while controller expiry uses serialized deadline scheduling, recovery-safe invalid timing, and deduplicated verified completion notices | `docs/recurrences-and-pomodoro.md` | `src/app/use-pomodoro-controller.ts`, `src/app/use-pomodoro-timing.ts`, Pomodoro tests |
 | 2026-07-29 | Bootstrapped the full agent-maintained documentation system: architecture, persistence, daily routines, reviews/goals, GTD, recurrences/Pomodoro, AI/privacy, conventions, and desktop builds | `AGENTS.md`, `docs/*.md` | Current source tree, tests, Tauri configuration, comparison with the Bâtisseurs documentation structure |
 
 ## Entry template

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,7 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-08-12 | Retry Pomodoro history/summary snapshots after a transient list-read failure so the page cannot stay on pre-action history after the active session already updated | `docs/recurrences-and-pomodoro.md` | `src/app/use-pomodoro-controller.ts`, Pomodoro controller tests |
 | 2026-07-30 | Hardened Pomodoro expiry against malformed deadlines, action/deadline races, and transient post-expiry refresh failures | `docs/recurrences-and-pomodoro.md` | `src/lib/pomodoro/engine.ts`, `src/app/use-pomodoro-controller.ts`, Pomodoro tests |
 | 2026-07-30 | Reworked Pomodoro timing so display ticks are local to timer views while controller expiry uses serialized deadline scheduling, recovery-safe invalid timing, and deduplicated verified completion notices | `docs/recurrences-and-pomodoro.md` | `src/app/use-pomodoro-controller.ts`, `src/app/use-pomodoro-timing.ts`, Pomodoro tests |
 | 2026-07-29 | Bootstrapped the full agent-maintained documentation system: architecture, persistence, daily routines, reviews/goals, GTD, recurrences/Pomodoro, AI/privacy, conventions, and desktop builds | `AGENTS.md`, `docs/*.md` | Current source tree, tests, Tauri configuration, comparison with the Bâtisseurs documentation structure |

--- a/docs/recurrences-and-pomodoro.md
+++ b/docs/recurrences-and-pomodoro.md
@@ -179,6 +179,11 @@ Pomodoro page share state.
   refresh only Pomodoro collections. Each ordinary action first reconciles a valid
   expired running session, so it cannot pause or alter an already elapsed timer.
   Snapshot commits ignore stale repository or unmounted-controller work.
+- After a persisted timer change, the controller publishes the new active session
+  immediately so the deadline scheduler stays aligned with SQLite. Session history
+  and task-summary snapshots load afterward. A transient list-read failure is
+  retried immediately and, if it still fails, once more after a short delay so
+  the Pomodoro page cannot keep showing pre-action history indefinitely.
 - Corrupt active timing data displays `--:--`; recovery controls remain available,
   while early completion is disabled.
 - An automatic completion is verified from the persisted local-date session list

--- a/docs/recurrences-and-pomodoro.md
+++ b/docs/recurrences-and-pomodoro.md
@@ -167,9 +167,24 @@ Eligible GTD tasks are active Next Actions and Scheduled tasks.
 `usePomodoroController` is mounted once in `AppProvider`, so the floating timer and
 Pomodoro page share state.
 
-- UI countdown state updates once per second.
-- Repository state is reloaded after every action.
-- Expired running sessions complete at their planned `endsAt`.
+- The shared controller does not run a global display clock. The floating timer and
+  Pomodoro page each use a local one-second display clock only while rendering a
+  valid running session; each tick calculates from the persisted deadline rather
+  than decrementing a counter. Paused sessions use their persisted remaining time.
+- A deadline scheduler, focus/visibility reconciliation, and a 30-second safety
+  reconciliation complete valid running sessions at `endsAt`. It is cleaned up on
+  session/repository changes and does not loop for malformed deadlines.
+- Timer actions, expiry, and explicit reloads are serialized. Full refreshes also
+  generate due recurrences and normalize expired sessions; ordinary timer actions
+  refresh only Pomodoro collections. Each ordinary action first reconciles a valid
+  expired running session, so it cannot pause or alter an already elapsed timer.
+  Snapshot commits ignore stale repository or unmounted-controller work.
+- Corrupt active timing data displays `--:--`; recovery controls remain available,
+  while early completion is disabled.
+- An automatic completion is verified from the persisted local-date session list
+  before the controller publishes its completed state, then chimes/notifies at
+  most once per repository lifetime in the mounted controller. A transient
+  ordinary-refresh failure therefore cannot suppress a verified notice.
 - Completing a focus or break through the controller plays a chime and requests a
   native/browser notification.
 - Starting/resuming tries to unlock audio from the user interaction first.

--- a/src/app/use-pomodoro-controller.test.tsx
+++ b/src/app/use-pomodoro-controller.test.tsx
@@ -146,12 +146,12 @@ describe("usePomodoroController", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
     const repository = await createRunningRepository();
+    const originalListPomodoroSessions = repository.listPomodoroSessions.bind(repository);
     const listPomodoroSessions = vi.spyOn(repository, "listPomodoroSessions");
     const { result } = renderHook(() => usePomodoroController(repository));
 
     await flushControllerQueue();
     listPomodoroSessions.mockClear();
-    const originalListPomodoroSessions = repository.listPomodoroSessions.bind(repository);
     listPomodoroSessions
       .mockImplementationOnce((date) => originalListPomodoroSessions(date))
       .mockRejectedValueOnce(new Error("temporary refresh failure"));
@@ -161,7 +161,57 @@ describe("usePomodoroController", () => {
     await flushControllerQueue();
 
     expect(result.current.state.activeSession).toBeNull();
+    expect(result.current.sessions[0]?.status).toBe("completed");
     expect((await originalListPomodoroSessions("2026-04-01"))[0]?.status).toBe("completed");
     expect(announceCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps session history aligned after a timer action whose list refresh fails once", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const listPomodoroSessions = vi.spyOn(repository, "listPomodoroSessions");
+    const { result } = renderHook(() => usePomodoroController(repository));
+
+    await flushControllerQueue();
+    expect(result.current.sessions[0]?.status).toBe("running");
+    listPomodoroSessions.mockClear();
+    listPomodoroSessions.mockRejectedValueOnce(new Error("temporary refresh failure"));
+
+    await act(async () => {
+      await result.current.pauseCurrent();
+    });
+
+    expect(result.current.state.activeSession?.status).toBe("paused");
+    expect(result.current.sessions[0]?.status).toBe("paused");
+  });
+
+  it("retries a stale history snapshot after repeated list refresh failures", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const listPomodoroSessions = vi.spyOn(repository, "listPomodoroSessions");
+    const { result } = renderHook(() => usePomodoroController(repository));
+
+    await flushControllerQueue();
+    expect(result.current.sessions[0]?.status).toBe("running");
+    listPomodoroSessions.mockClear();
+    listPomodoroSessions
+      .mockRejectedValueOnce(new Error("temporary refresh failure"))
+      .mockRejectedValueOnce(new Error("temporary refresh failure"));
+
+    await act(async () => {
+      await result.current.pauseCurrent();
+    });
+
+    expect(result.current.state.activeSession?.status).toBe("paused");
+    expect(result.current.sessions[0]?.status).toBe("running");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    await flushControllerQueue();
+
+    expect(result.current.sessions[0]?.status).toBe("paused");
   });
 });

--- a/src/app/use-pomodoro-controller.test.tsx
+++ b/src/app/use-pomodoro-controller.test.tsx
@@ -1,0 +1,167 @@
+import { act, renderHook } from "@testing-library/react";
+import { StrictMode, type PropsWithChildren } from "react";
+import type { PomodoroSession } from "../domain/types";
+import { MemoryRepository } from "../lib/storage/memory-repository";
+
+const { announceCompletion } = vi.hoisted(() => ({ announceCompletion: vi.fn(async () => undefined) }));
+
+vi.mock("../lib/pomodoro/sound", () => ({
+  unlockPomodoroSound: vi.fn(async () => undefined),
+  playPomodoroChime: vi.fn(async () => undefined),
+  notifyPomodoroCompletion: announceCompletion,
+  resolvePomodoroChimeVariant: vi.fn(() => "focus")
+}));
+
+import { usePomodoroController } from "./use-pomodoro-controller";
+
+describe("usePomodoroController", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    announceCompletion.mockClear();
+  });
+
+  const createRunningRepository = async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    await repository.startPomodoro();
+    return repository;
+  };
+
+  const flushControllerQueue = async () => {
+    await act(async () => {
+      for (let index = 0; index < 12; index += 1) {
+        await Promise.resolve();
+      }
+    });
+  };
+
+  it("uses one deadline scheduler and announces an expiry once under StrictMode", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const completeExpired = vi.spyOn(repository, "completeExpiredPomodoroSessions");
+    const wrapper = ({ children }: PropsWithChildren) => <StrictMode>{children}</StrictMode>;
+    const { result } = renderHook(() => usePomodoroController(repository), { wrapper });
+
+    await flushControllerQueue();
+    expect(result.current.state.activeSession?.status).toBe("running");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(25 * 60 * 1000);
+    });
+    await flushControllerQueue();
+    expect(result.current.state.activeSession).toBeNull();
+
+    expect(completeExpired).toHaveBeenCalled();
+    expect(announceCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles a missed deadline on visibility and does not publish a one-second controller value", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const { result } = renderHook(() => usePomodoroController(repository));
+
+    await flushControllerQueue();
+    expect(result.current.state.activeSession?.status).toBe("running");
+    const stableControllerValue = result.current;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(result.current).toBe(stableControllerValue);
+
+    vi.setSystemTime(new Date("2026-04-01T09:25:01.000Z"));
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+    await flushControllerQueue();
+    expect(result.current.state.activeSession).toBeNull();
+    expect(announceCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes competing timer actions against the session current when each executes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const { result } = renderHook(() => usePomodoroController(repository));
+
+    await flushControllerQueue();
+    await act(async () => {
+      await Promise.all([result.current.pauseCurrent(), result.current.cancelCurrent()]);
+    });
+
+    expect(result.current.state.activeSession).toBeNull();
+    expect((await repository.listPomodoroSessions("2026-04-01"))[0]?.status).toBe("cancelled");
+  });
+
+  it("keeps malformed running storage visible to the controller so it can be recovered", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const sessions = (repository as unknown as { pomodoroSessions: Map<string, PomodoroSession> }).pomodoroSessions;
+    const [session] = [...sessions.values()];
+    sessions.set(session.id, { ...session, endsAt: "not-a-date" });
+    const { result } = renderHook(() => usePomodoroController(repository));
+
+    await flushControllerQueue();
+    expect(result.current.state.activeSession).toMatchObject({
+      id: session.id,
+      status: "running",
+      endsAt: "not-a-date"
+    });
+
+    await act(async () => {
+      await result.current.cancelCurrent();
+    });
+    expect((await repository.listPomodoroSessions("2026-04-01"))[0]?.status).toBe("cancelled");
+  });
+
+  it("completes an expired session before queued actions can pause or switch it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const pause = vi.spyOn(repository, "pausePomodoroSession");
+    const switchTask = vi.spyOn(repository, "switchPomodoroTask");
+    const { result } = renderHook(() => usePomodoroController(repository));
+
+    await flushControllerQueue();
+    pause.mockClear();
+    switchTask.mockClear();
+    vi.setSystemTime(new Date("2026-04-01T09:25:00.000Z"));
+    await act(async () => {
+      const paused = result.current.pauseCurrent();
+      const switched = result.current.switchTask(null, "Too late");
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.all([paused, switched]);
+    });
+    await flushControllerQueue();
+
+    expect((await repository.listPomodoroSessions("2026-04-01"))[0]?.status).toBe("completed");
+    expect(pause).not.toHaveBeenCalled();
+    expect(switchTask).not.toHaveBeenCalled();
+    expect(announceCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces a persisted expiry even when its ordinary refresh transiently fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const repository = await createRunningRepository();
+    const listPomodoroSessions = vi.spyOn(repository, "listPomodoroSessions");
+    const { result } = renderHook(() => usePomodoroController(repository));
+
+    await flushControllerQueue();
+    listPomodoroSessions.mockClear();
+    const originalListPomodoroSessions = repository.listPomodoroSessions.bind(repository);
+    listPomodoroSessions
+      .mockImplementationOnce((date) => originalListPomodoroSessions(date))
+      .mockRejectedValueOnce(new Error("temporary refresh failure"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(25 * 60 * 1000);
+    });
+    await flushControllerQueue();
+
+    expect(result.current.state.activeSession).toBeNull();
+    expect((await originalListPomodoroSessions("2026-04-01"))[0]?.status).toBe("completed");
+    expect(announceCompletion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/use-pomodoro-controller.ts
+++ b/src/app/use-pomodoro-controller.ts
@@ -45,6 +45,25 @@ const buildIdleState = (): PomodoroState => ({
 
 const isBreak = (kind: PomodoroSessionDetails["kind"]): boolean => kind === "short_break" || kind === "long_break";
 
+const POMODORO_LIST_RETRY_DELAY_MS = 1_000;
+
+const withTransientRetry = async <T,>(label: string, operation: () => Promise<T>): Promise<T> => {
+  try {
+    return await operation();
+  } catch (error) {
+    logDebug("error", "pomodoro", `Echec transitoire de ${label}`, error);
+    return operation();
+  }
+};
+
+const readTodayPomodoroLists = (candidate: AppRepository) => {
+  const today = getTodayDate();
+  return Promise.all([
+    candidate.listPomodoroSessions(today),
+    candidate.listPomodoroTaskSummaries(today)
+  ]);
+};
+
 /** Shared timer state and serialized persistence orchestration for the application shell. */
 export const usePomodoroController = (repository: AppRepository | null): PomodoroControllerValue => {
   const [state, setState] = useState<PomodoroState>(buildIdleState());
@@ -59,22 +78,42 @@ export const usePomodoroController = (repository: AppRepository | null): Pomodor
   const snapshotTokenRef = useRef(0);
   const announcedCompletionIdsRef = useRef(new Set<string>());
   const invalidDeadlineKeysRef = useRef(new Set<string>());
+  const listRetryTimeoutRef = useRef<number | undefined>(undefined);
+  const refreshPomodoroRef = useRef<(
+    candidate: AppRepository,
+    nextState?: PomodoroState,
+    options?: { scheduleRetry?: boolean }
+  ) => Promise<void>>(async () => undefined);
+  const refreshEverythingRef = useRef<(
+    candidate: AppRepository,
+    showLoading: boolean,
+    options?: { scheduleRetry?: boolean }
+  ) => Promise<void>>(async () => undefined);
 
   repositoryRef.current = repository;
+
+  const clearListRetryTimeout = useCallback(() => {
+    if (listRetryTimeoutRef.current !== undefined) {
+      window.clearTimeout(listRetryTimeoutRef.current);
+      listRetryTimeoutRef.current = undefined;
+    }
+  }, []);
 
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       snapshotTokenRef.current += 1;
+      clearListRetryTimeout();
     };
-  }, []);
+  }, [clearListRetryTimeout]);
 
   useEffect(() => {
     snapshotTokenRef.current += 1;
     announcedCompletionIdsRef.current = new Set();
     invalidDeadlineKeysRef.current = new Set();
-  }, [repository]);
+    clearListRetryTimeout();
+  }, [clearListRetryTimeout, repository]);
 
   const isCurrentRepository = useCallback((candidate: AppRepository) =>
     mountedRef.current && repositoryRef.current === candidate, []);
@@ -111,17 +150,49 @@ export const usePomodoroController = (repository: AppRepository | null): Pomodor
     setState(nextState);
   }, [isCurrentRepository]);
 
-  const refreshPomodoro = useCallback(async (candidate: AppRepository, nextState?: PomodoroState) => {
+  const scheduleSnapshotRetry = useCallback((
+    candidate: AppRepository,
+    token: number,
+    retry: (candidate: AppRepository) => Promise<void>
+  ) => {
+    if (!isCurrentRepository(candidate) || token !== snapshotTokenRef.current) {
+      return;
+    }
+    clearListRetryTimeout();
+    listRetryTimeoutRef.current = window.setTimeout(() => {
+      listRetryTimeoutRef.current = undefined;
+      void runQueued("rafraichissement des listes Pomodoro", async () => {
+        await retry(candidate);
+      });
+    }, POMODORO_LIST_RETRY_DELAY_MS);
+  }, [clearListRetryTimeout, isCurrentRepository, runQueued]);
+
+  const refreshPomodoro = useCallback(async (
+    candidate: AppRepository,
+    nextState?: PomodoroState,
+    options?: { scheduleRetry?: boolean }
+  ) => {
     const token = ++snapshotTokenRef.current;
+    clearListRetryTimeout();
     if (nextState) {
       applyState(candidate, nextState);
     }
 
-    const today = getTodayDate();
-    const [nextSessions, nextSummaries] = await Promise.all([
-      candidate.listPomodoroSessions(today),
-      candidate.listPomodoroTaskSummaries(today)
-    ]);
+    let nextSessions: PomodoroSessionDetails[];
+    let nextSummaries: PomodoroTaskSummary[];
+    try {
+      [nextSessions, nextSummaries] = await withTransientRetry(
+        "rafraichissement des listes Pomodoro",
+        () => readTodayPomodoroLists(candidate)
+      );
+    } catch (error) {
+      if (options?.scheduleRetry ?? true) {
+        scheduleSnapshotRetry(candidate, token, (nextCandidate) =>
+          refreshPomodoroRef.current(nextCandidate, undefined, { scheduleRetry: false })
+        );
+      }
+      throw error;
+    }
 
     if (!isCurrentRepository(candidate) || token !== snapshotTokenRef.current) {
       return;
@@ -129,10 +200,15 @@ export const usePomodoroController = (repository: AppRepository | null): Pomodor
     setSessions(nextSessions);
     setTaskSummaries(nextSummaries);
     setLoading(false);
-  }, [applyState, isCurrentRepository]);
+  }, [applyState, clearListRetryTimeout, isCurrentRepository, scheduleSnapshotRetry]);
 
-  const refreshEverything = useCallback(async (candidate: AppRepository, showLoading: boolean) => {
+  const refreshEverything = useCallback(async (
+    candidate: AppRepository,
+    showLoading: boolean,
+    options?: { scheduleRetry?: boolean }
+  ) => {
     const token = ++snapshotTokenRef.current;
+    clearListRetryTimeout();
     if (showLoading && isCurrentRepository(candidate)) {
       setLoading(true);
     }
@@ -141,11 +217,26 @@ export const usePomodoroController = (repository: AppRepository | null): Pomodor
     await candidate.generateDueRecurringTasks(today);
     const nextState = await candidate.completeExpiredPomodoroSessions();
     applyState(candidate, nextState);
-    const [nextSessions, nextSummaries, nextTasks] = await Promise.all([
-      candidate.listPomodoroSessions(today),
-      candidate.listPomodoroTaskSummaries(today),
-      candidate.listTasks({ includeCompleted: true })
-    ]);
+    let nextSessions: PomodoroSessionDetails[];
+    let nextSummaries: PomodoroTaskSummary[];
+    let nextTasks: Task[];
+    try {
+      [nextSessions, nextSummaries, nextTasks] = await withTransientRetry(
+        "rafraichissement Pomodoro",
+        () => Promise.all([
+          candidate.listPomodoroSessions(today),
+          candidate.listPomodoroTaskSummaries(today),
+          candidate.listTasks({ includeCompleted: true })
+        ])
+      );
+    } catch (error) {
+      if (options?.scheduleRetry ?? true) {
+        scheduleSnapshotRetry(candidate, token, (nextCandidate) =>
+          refreshEverythingRef.current(nextCandidate, false, { scheduleRetry: false })
+        );
+      }
+      throw error;
+    }
 
     if (!isCurrentRepository(candidate) || token !== snapshotTokenRef.current) {
       return;
@@ -154,7 +245,10 @@ export const usePomodoroController = (repository: AppRepository | null): Pomodor
     setTaskSummaries(nextSummaries);
     setAllTasks(nextTasks);
     setLoading(false);
-  }, [applyState, isCurrentRepository]);
+  }, [applyState, clearListRetryTimeout, isCurrentRepository, scheduleSnapshotRetry]);
+
+  refreshPomodoroRef.current = refreshPomodoro;
+  refreshEverythingRef.current = refreshEverything;
 
   useEffect(() => {
     if (!repository) {

--- a/src/app/use-pomodoro-controller.ts
+++ b/src/app/use-pomodoro-controller.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PomodoroSessionDetails, PomodoroState, PomodoroTaskSummary, Task } from "../domain/types";
 import { getTodayDate } from "../lib/date";
 import { logDebug } from "../lib/debug";
-import { getPomodoroDurationMs, getPomodoroKindLabel } from "../lib/pomodoro/engine";
+import { getPomodoroTiming, getPomodoroKindLabel } from "../lib/pomodoro/engine";
 import {
   notifyPomodoroCompletion,
   playPomodoroChime,
@@ -20,8 +20,6 @@ export interface PomodoroControllerValue {
   currentActivityLabel: string | null;
   preferredTask: Task | null;
   preferredActivityLabel: string | null;
-  remainingMs: number;
-  canCompleteNow: boolean;
   loading: boolean;
   reload: () => Promise<void>;
   startPomodoro: (options?: PomodoroStartOptions) => Promise<void>;
@@ -45,273 +43,434 @@ const buildIdleState = (): PomodoroState => ({
   currentCycleIndex: 1
 });
 
+const isBreak = (kind: PomodoroSessionDetails["kind"]): boolean => kind === "short_break" || kind === "long_break";
+
+/** Shared timer state and serialized persistence orchestration for the application shell. */
 export const usePomodoroController = (repository: AppRepository | null): PomodoroControllerValue => {
   const [state, setState] = useState<PomodoroState>(buildIdleState());
   const [sessions, setSessions] = useState<PomodoroSessionDetails[]>([]);
   const [taskSummaries, setTaskSummaries] = useState<PomodoroTaskSummary[]>([]);
   const [allTasks, setAllTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
-  const [nowMs, setNowMs] = useState(Date.now());
   const stateRef = useRef<PomodoroState>(buildIdleState());
-  const refreshRunningRef = useRef(false);
+  const repositoryRef = useRef<AppRepository | null>(repository);
+  const mountedRef = useRef(false);
+  const queueRef = useRef<Promise<void>>(Promise.resolve());
+  const snapshotTokenRef = useRef(0);
+  const announcedCompletionIdsRef = useRef(new Set<string>());
+  const invalidDeadlineKeysRef = useRef(new Set<string>());
 
-  const announceCompletion = useCallback(
-    async (session: Pick<PomodoroSessionDetails, "kind" | "cycleIndex">) => {
-      const variant = resolvePomodoroChimeVariant(session.kind, session.cycleIndex);
-      await playPomodoroChime(variant);
-      await notifyPomodoroCompletion(
-        "Session Pomodoro terminee",
-        `${getPomodoroKindLabel(session.kind)} terminee.`
-      );
-    },
-    []
-  );
-
-  const load = useCallback(
-    async (options?: { preserveVisibleState?: boolean }) => {
-      if (!repository) {
-        setLoading(false);
-        return;
-      }
-
-      if (!options?.preserveVisibleState) {
-        setLoading(true);
-      }
-
-      const today = getTodayDate();
-      await repository.generateDueRecurringTasks(today);
-      const nextState = await repository.completeExpiredPomodoroSessions();
-      const [nextSessions, nextSummaries, nextTasks] = await Promise.all([
-        repository.listPomodoroSessions(today),
-        repository.listPomodoroTaskSummaries(today),
-        repository.listTasks({ includeCompleted: true })
-      ]);
-
-      stateRef.current = nextState;
-      setState(nextState);
-      setSessions(nextSessions);
-      setTaskSummaries(nextSummaries);
-      setAllTasks(nextTasks);
-      setLoading(false);
-      setNowMs(Date.now());
-    },
-    [repository]
-  );
+  repositoryRef.current = repository;
 
   useEffect(() => {
-    void load();
-  }, [load]);
-
-  useEffect(() => {
-    const intervalId = window.setInterval(() => {
-      setNowMs(Date.now());
-    }, 1000);
-
+    mountedRef.current = true;
     return () => {
-      window.clearInterval(intervalId);
+      mountedRef.current = false;
+      snapshotTokenRef.current += 1;
     };
   }, []);
 
   useEffect(() => {
-    const activeSession = state.activeSession;
+    snapshotTokenRef.current += 1;
+    announcedCompletionIdsRef.current = new Set();
+    invalidDeadlineKeysRef.current = new Set();
+  }, [repository]);
 
+  const isCurrentRepository = useCallback((candidate: AppRepository) =>
+    mountedRef.current && repositoryRef.current === candidate, []);
+
+  const announceCompletion = useCallback(async (session: Pick<PomodoroSessionDetails, "kind" | "cycleIndex">) => {
+    const variant = resolvePomodoroChimeVariant(session.kind, session.cycleIndex);
+    await playPomodoroChime(variant);
+    await notifyPomodoroCompletion(
+      "Session Pomodoro terminee",
+      `${getPomodoroKindLabel(session.kind)} terminee.`
+    );
+  }, []);
+
+  const enqueue = useCallback(<T,>(operation: () => Promise<T>): Promise<T> => {
+    const run = queueRef.current.then(operation);
+    // Keep later work runnable even if a caller observes (or ignores) a rejected action.
+    queueRef.current = run.then(() => undefined, () => undefined);
+    return run;
+  }, []);
+
+  const runQueued = useCallback(async (label: string, operation: () => Promise<void>) => {
+    try {
+      await enqueue(operation);
+    } catch (error) {
+      logDebug("error", "pomodoro", `Echec de ${label}`, error);
+    }
+  }, [enqueue]);
+
+  const applyState = useCallback((candidate: AppRepository, nextState: PomodoroState) => {
+    if (!isCurrentRepository(candidate)) {
+      return;
+    }
+    stateRef.current = nextState;
+    setState(nextState);
+  }, [isCurrentRepository]);
+
+  const refreshPomodoro = useCallback(async (candidate: AppRepository, nextState?: PomodoroState) => {
+    const token = ++snapshotTokenRef.current;
+    if (nextState) {
+      applyState(candidate, nextState);
+    }
+
+    const today = getTodayDate();
+    const [nextSessions, nextSummaries] = await Promise.all([
+      candidate.listPomodoroSessions(today),
+      candidate.listPomodoroTaskSummaries(today)
+    ]);
+
+    if (!isCurrentRepository(candidate) || token !== snapshotTokenRef.current) {
+      return;
+    }
+    setSessions(nextSessions);
+    setTaskSummaries(nextSummaries);
+    setLoading(false);
+  }, [applyState, isCurrentRepository]);
+
+  const refreshEverything = useCallback(async (candidate: AppRepository, showLoading: boolean) => {
+    const token = ++snapshotTokenRef.current;
+    if (showLoading && isCurrentRepository(candidate)) {
+      setLoading(true);
+    }
+
+    const today = getTodayDate();
+    await candidate.generateDueRecurringTasks(today);
+    const nextState = await candidate.completeExpiredPomodoroSessions();
+    applyState(candidate, nextState);
+    const [nextSessions, nextSummaries, nextTasks] = await Promise.all([
+      candidate.listPomodoroSessions(today),
+      candidate.listPomodoroTaskSummaries(today),
+      candidate.listTasks({ includeCompleted: true })
+    ]);
+
+    if (!isCurrentRepository(candidate) || token !== snapshotTokenRef.current) {
+      return;
+    }
+    setSessions(nextSessions);
+    setTaskSummaries(nextSummaries);
+    setAllTasks(nextTasks);
+    setLoading(false);
+  }, [applyState, isCurrentRepository]);
+
+  useEffect(() => {
+    if (!repository) {
+      setLoading(false);
+      return;
+    }
+    void runQueued("chargement Pomodoro", async () => refreshEverything(repository, true));
+  }, [refreshEverything, repository, runQueued]);
+
+  const completeExpiredSessionIfCurrent = useCallback(async (
+    candidate: AppRepository,
+    captured: PomodoroSessionDetails
+  ): Promise<boolean> => {
+    if (!isCurrentRepository(candidate)) {
+      return false;
+    }
+    const activeSession = stateRef.current.activeSession;
+    if (
+      !activeSession ||
+      activeSession.id !== captured.id ||
+      activeSession.status !== "running" ||
+      activeSession.endsAt !== captured.endsAt
+    ) {
+      return false;
+    }
+    const timing = getPomodoroTiming(activeSession, Date.now());
+    if (!timing.valid || timing.remainingMs > 0) {
+      return false;
+    }
+
+    const nextState = await candidate.completeExpiredPomodoroSessions();
+    // Verify the exact persisted local-date record before publishing a null state. If this
+    // read fails, stateRef remains running and the next reconciliation can safely retry.
+    const persistedSessions = await candidate.listPomodoroSessions(captured.date);
+    const persisted = persistedSessions.find((session) => session.id === captured.id);
+    if (persisted?.status !== "completed") {
+      logDebug("error", "pomodoro", "Session expiree non verifiee apres persistance", {
+        sessionId: captured.id,
+        date: captured.date
+      });
+      return true;
+    }
+
+    applyState(candidate, nextState);
+    if (!announcedCompletionIdsRef.current.has(captured.id)) {
+      announcedCompletionIdsRef.current.add(captured.id);
+      await announceCompletion(captured);
+    }
+    await refreshPomodoro(candidate);
+    return true;
+  }, [announceCompletion, applyState, isCurrentRepository, refreshPomodoro]);
+
+  const reconcileExpiredActiveSession = useCallback(async (candidate: AppRepository): Promise<boolean> => {
+    const activeSession = stateRef.current.activeSession;
+    return activeSession?.status === "running"
+      ? completeExpiredSessionIfCurrent(candidate, activeSession)
+      : false;
+  }, [completeExpiredSessionIfCurrent]);
+
+  const processExpiry = useCallback((candidate: AppRepository, captured: PomodoroSessionDetails) =>
+    runQueued("completion automatique d'une session", async () => {
+      await completeExpiredSessionIfCurrent(candidate, captured);
+    }),
+  [completeExpiredSessionIfCurrent, runQueued]);
+
+  useEffect(() => {
+    const activeSession = state.activeSession;
     if (!repository || !activeSession || activeSession.status !== "running") {
       return;
     }
 
-    const expiringSession = activeSession;
-    const sessionEndsAtMs = new Date(expiringSession.endsAt).getTime();
-
-    if (nowMs < sessionEndsAtMs || refreshRunningRef.current) {
+    const timing = getPomodoroTiming(activeSession, Date.now());
+    if (!timing.valid) {
+      const key = `${activeSession.id}:${activeSession.endsAt}`;
+      if (!invalidDeadlineKeysRef.current.has(key)) {
+        invalidDeadlineKeysRef.current.add(key);
+        logDebug("error", "pomodoro", "Deadline Pomodoro invalide; aucun planificateur active", {
+          sessionId: activeSession.id,
+          endsAt: activeSession.endsAt
+        });
+      }
       return;
     }
 
-    refreshRunningRef.current = true;
-
-    const complete = async () => {
-      try {
-        await repository.completeExpiredPomodoroSessions();
-        await announceCompletion(expiringSession);
-        await load({ preserveVisibleState: true });
-      } catch (error) {
-        logDebug("error", "pomodoro", "Echec de completion automatique d'une session", error);
-      } finally {
-        refreshRunningRef.current = false;
+    let timeoutId: number | undefined;
+    const reconcile = () => {
+      const current = stateRef.current.activeSession;
+      if (!current || current.id !== activeSession.id || current.status !== "running") {
+        return;
+      }
+      const currentTiming = getPomodoroTiming(current, Date.now());
+      if (!currentTiming.valid) {
+        return;
+      }
+      const deadlineRemainingMs = new Date(current.endsAt).getTime() - Date.now();
+      if (deadlineRemainingMs <= 0) {
+        void processExpiry(repository, current);
+        return;
+      }
+      window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(reconcile, Math.min(deadlineRemainingMs, 2_147_483_647));
+    };
+    const reconcileWhenVisible = () => {
+      if (document.visibilityState === "visible") {
+        reconcile();
       }
     };
 
-    void complete();
-  }, [announceCompletion, load, nowMs, repository, state.activeSession]);
+    reconcile();
+    const intervalId = window.setInterval(reconcile, 30_000);
+    window.addEventListener("focus", reconcile);
+    document.addEventListener("visibilitychange", reconcileWhenVisible);
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", reconcile);
+      document.removeEventListener("visibilitychange", reconcileWhenVisible);
+    };
+  }, [
+    processExpiry,
+    repository,
+    state.activeSession?.endsAt,
+    state.activeSession?.id,
+    state.activeSession?.status
+  ]);
 
-  const startPomodoro = useCallback(
-    async (options: PomodoroStartOptions = {}) => {
-      if (!repository) {
+  const startPomodoro = useCallback(async (options: PomodoroStartOptions = {}) => {
+    if (!repository) {
+      return;
+    }
+    await unlockPomodoroSound();
+    await runQueued("demarrage Pomodoro", async () => {
+      if (await reconcileExpiredActiveSession(repository)) {
         return;
       }
-
-      await unlockPomodoroSound();
-      await repository.startPomodoro(options);
-      await load({ preserveVisibleState: true });
-    },
-    [load, repository]
-  );
+      if (!isCurrentRepository(repository) || stateRef.current.activeSession) {
+        return;
+      }
+      const nextState = await repository.startPomodoro(options);
+      await refreshPomodoro(repository, nextState);
+    });
+  }, [isCurrentRepository, reconcileExpiredActiveSession, refreshPomodoro, repository, runQueued]);
 
   const pauseCurrent = useCallback(async () => {
-    const activeSession = stateRef.current.activeSession;
-    if (!repository || !activeSession || activeSession.status !== "running") {
+    if (!repository) {
       return;
     }
-
-    await repository.pausePomodoroSession(activeSession.id);
-    await load({ preserveVisibleState: true });
-  }, [load, repository]);
+    await runQueued("mise en pause Pomodoro", async () => {
+      if (await reconcileExpiredActiveSession(repository)) {
+        return;
+      }
+      const activeSession = stateRef.current.activeSession;
+      if (!isCurrentRepository(repository) || !activeSession || activeSession.status !== "running") {
+        return;
+      }
+      const nextState = await repository.pausePomodoroSession(activeSession.id);
+      await refreshPomodoro(repository, nextState);
+    });
+  }, [isCurrentRepository, reconcileExpiredActiveSession, refreshPomodoro, repository, runQueued]);
 
   const resumeCurrent = useCallback(async () => {
-    const activeSession = stateRef.current.activeSession;
-    if (!repository || !activeSession || activeSession.status !== "paused") {
+    if (!repository) {
       return;
     }
-
     await unlockPomodoroSound();
-    await repository.resumePomodoroSession(activeSession.id);
-    await load({ preserveVisibleState: true });
-  }, [load, repository]);
+    await runQueued("reprise Pomodoro", async () => {
+      const activeSession = stateRef.current.activeSession;
+      if (!isCurrentRepository(repository) || !activeSession || activeSession.status !== "paused") {
+        return;
+      }
+      const nextState = await repository.resumePomodoroSession(activeSession.id);
+      await refreshPomodoro(repository, nextState);
+    });
+  }, [isCurrentRepository, refreshPomodoro, repository, runQueued]);
 
   const completeNow = useCallback(async () => {
-    const activeSession = stateRef.current.activeSession;
-    if (!repository || !activeSession) {
+    if (!repository) {
       return;
     }
-
-    const elapsedMs =
-      getPomodoroDurationMs(activeSession.kind) -
-      (activeSession.pausedRemainingMs ?? Math.max(0, new Date(activeSession.endsAt).getTime() - Date.now()));
-    if (activeSession.kind === "focus" && elapsedMs < getPomodoroDurationMs("focus") / 2) {
-      return;
-    }
-
-    await repository.stopPomodoroSession(activeSession.id, "completed");
-    await announceCompletion(activeSession);
-    await load({ preserveVisibleState: true });
-  }, [announceCompletion, load, repository]);
+    await runQueued("completion manuelle Pomodoro", async () => {
+      if (await reconcileExpiredActiveSession(repository)) {
+        return;
+      }
+      const activeSession = stateRef.current.activeSession;
+      if (!isCurrentRepository(repository) || !activeSession || !getPomodoroTiming(activeSession, Date.now()).canCompleteNow) {
+        return;
+      }
+      const nextState = await repository.stopPomodoroSession(activeSession.id, "completed");
+      applyState(repository, nextState);
+      await announceCompletion(activeSession);
+      await refreshPomodoro(repository, nextState);
+    });
+  }, [announceCompletion, applyState, isCurrentRepository, reconcileExpiredActiveSession, refreshPomodoro, repository, runQueued]);
 
   const completeCurrentTask = useCallback(async () => {
-    const activeSession = stateRef.current.activeSession;
-    const currentTaskId = activeSession?.activeTaskId;
-
-    if (!repository || !activeSession || activeSession.status !== "running" || activeSession.kind !== "focus" || !currentTaskId) {
+    if (!repository) {
       return;
     }
-
-    await repository.completeTask(currentTaskId);
-    await repository.switchPomodoroTask(activeSession.id, null, null);
-    await load({ preserveVisibleState: true });
-  }, [load, repository]);
+    await runQueued("completion de la tache Pomodoro", async () => {
+      if (await reconcileExpiredActiveSession(repository)) {
+        return;
+      }
+      const activeSession = stateRef.current.activeSession;
+      const currentTaskId = activeSession?.activeTaskId;
+      if (!isCurrentRepository(repository) || !activeSession || activeSession.status !== "running" || activeSession.kind !== "focus" || !currentTaskId) {
+        return;
+      }
+      await repository.completeTask(currentTaskId);
+      const nextState = await repository.switchPomodoroTask(activeSession.id, null, null);
+      applyState(repository, nextState);
+      await refreshEverything(repository, false);
+    });
+  }, [applyState, isCurrentRepository, reconcileExpiredActiveSession, refreshEverything, repository, runQueued]);
 
   const skipBreak = useCallback(async () => {
     if (!repository) {
       return;
     }
-
-    const activeSession = stateRef.current.activeSession;
-
-    if (activeSession?.kind === "short_break" || activeSession?.kind === "long_break") {
-      await repository.stopPomodoroSession(activeSession.id, "completed");
-      await announceCompletion(activeSession);
-      await load({ preserveVisibleState: true });
-      return;
-    }
-
-    if (stateRef.current.nextSessionKind === "short_break" || stateRef.current.nextSessionKind === "long_break") {
-      const startedState = await repository.startPomodoro({
-        kind: stateRef.current.nextSessionKind
-      });
-      const startedBreak = startedState.activeSession;
-
-      if (startedBreak) {
-        await repository.stopPomodoroSession(startedBreak.id, "completed");
-        await announceCompletion(startedBreak);
-      }
-
-      await load({ preserveVisibleState: true });
-    }
-  }, [announceCompletion, load, repository]);
-
-  const cancelCurrent = useCallback(async () => {
-    const activeSession = stateRef.current.activeSession;
-    if (!repository || !activeSession) {
-      return;
-    }
-
-    await repository.stopPomodoroSession(activeSession.id, "cancelled");
-    await load({ preserveVisibleState: true });
-  }, [load, repository]);
-
-  const switchTask = useCallback(
-    async (taskId: string | null, title: string | null = null) => {
-      const activeSession = stateRef.current.activeSession;
-      if (!repository || !activeSession) {
+    await runQueued("saut de pause Pomodoro", async () => {
+      if (!isCurrentRepository(repository)) {
         return;
       }
+      if (await reconcileExpiredActiveSession(repository)) {
+        return;
+      }
+      const activeSession = stateRef.current.activeSession;
+      if (activeSession && isBreak(activeSession.kind)) {
+        const nextState = await repository.stopPomodoroSession(activeSession.id, "completed");
+        applyState(repository, nextState);
+        await announceCompletion(activeSession);
+        await refreshPomodoro(repository, nextState);
+        return;
+      }
+      if (activeSession || !isBreak(stateRef.current.nextSessionKind)) {
+        return;
+      }
+      const startedState = await repository.startPomodoro({ kind: stateRef.current.nextSessionKind });
+      applyState(repository, startedState);
+      const startedBreak = startedState.activeSession;
+      if (!startedBreak) {
+        await refreshPomodoro(repository, startedState);
+        return;
+      }
+      const nextState = await repository.stopPomodoroSession(startedBreak.id, "completed");
+      applyState(repository, nextState);
+      await announceCompletion(startedBreak);
+      await refreshPomodoro(repository, nextState);
+    });
+  }, [announceCompletion, applyState, isCurrentRepository, reconcileExpiredActiveSession, refreshPomodoro, repository, runQueued]);
 
-      await repository.switchPomodoroTask(activeSession.id, taskId, title);
-      await load({ preserveVisibleState: true });
-    },
-    [load, repository]
-  );
+  const cancelCurrent = useCallback(async () => {
+    if (!repository) {
+      return;
+    }
+    await runQueued("annulation Pomodoro", async () => {
+      if (await reconcileExpiredActiveSession(repository)) {
+        return;
+      }
+      const activeSession = stateRef.current.activeSession;
+      if (!isCurrentRepository(repository) || !activeSession) {
+        return;
+      }
+      const nextState = await repository.stopPomodoroSession(activeSession.id, "cancelled");
+      await refreshPomodoro(repository, nextState);
+    });
+  }, [isCurrentRepository, reconcileExpiredActiveSession, refreshPomodoro, repository, runQueued]);
+
+  const switchTask = useCallback(async (taskId: string | null, title: string | null = null) => {
+    if (!repository) {
+      return;
+    }
+    await runQueued("changement de tache Pomodoro", async () => {
+      if (await reconcileExpiredActiveSession(repository)) {
+        return;
+      }
+      const activeSession = stateRef.current.activeSession;
+      if (!isCurrentRepository(repository) || !activeSession) {
+        return;
+      }
+      const nextState = await repository.switchPomodoroTask(activeSession.id, taskId, title);
+      await refreshPomodoro(repository, nextState);
+    });
+  }, [isCurrentRepository, reconcileExpiredActiveSession, refreshPomodoro, repository, runQueued]);
+
+  const reload = useCallback(async () => {
+    if (!repository) {
+      return;
+    }
+    await runQueued("rechargement Pomodoro", async () => refreshEverything(repository, false));
+  }, [refreshEverything, repository, runQueued]);
 
   const currentActivityLabel = state.activeSession?.activeTaskId ? null : state.activeSession?.activeLabel ?? null;
-
   const currentTask = useMemo(() => {
     const taskId = state.activeSession?.activeTaskId;
-    if (!taskId) {
-      return null;
-    }
-
-    return allTasks.find((task) => task.id === taskId) ?? null;
+    return taskId ? allTasks.find((task) => task.id === taskId) ?? null : null;
   }, [allTasks, state.activeSession?.activeTaskId]);
-
-  const latestFocusSession = useMemo(
-    () => sessions.find((session) => session.kind === "focus"),
-    [sessions]
-  );
-
+  const latestFocusSession = useMemo(() => sessions.find((session) => session.kind === "focus"), [sessions]);
   const preferredSelection = useMemo(() => {
     if (currentTask || currentActivityLabel) {
       return { task: currentTask, label: currentActivityLabel };
     }
-
     const latestSegment = latestFocusSession?.segments.at(-1) ?? null;
     if (!latestSegment) {
       return { task: null, label: null };
     }
-
     if (latestSegment.taskId) {
-      const preferredTask = allTasks.find(
-        (task) => task.id === latestSegment.taskId && isPomodoroTaskEligible(task)
-      ) ?? null;
-      return { task: preferredTask, label: null };
+      return {
+        task: allTasks.find((task) => task.id === latestSegment.taskId && isPomodoroTaskEligible(task)) ?? null,
+        label: null
+      };
     }
-
     return { task: null, label: latestSegment.title ?? null };
   }, [allTasks, currentActivityLabel, currentTask, latestFocusSession]);
-
-  const canCompleteNow = useMemo(() => {
-    if (!state.activeSession || state.activeSession.kind !== "focus") {
-      return false;
-    }
-
-    const elapsedMs =
-      getPomodoroDurationMs("focus") -
-      (state.activeSession.status === "paused"
-        ? (state.activeSession.pausedRemainingMs ?? 0)
-        : Math.max(0, new Date(state.activeSession.endsAt).getTime() - nowMs));
-    return elapsedMs >= getPomodoroDurationMs("focus") / 2;
-  }, [nowMs, state.activeSession]);
-
   const taskOptions = useMemo(() => allTasks.filter(isPomodoroTaskEligible), [allTasks]);
 
-  return {
+  return useMemo(() => ({
     state,
     sessions,
     taskSummaries,
@@ -320,14 +479,8 @@ export const usePomodoroController = (repository: AppRepository | null): Pomodor
     currentActivityLabel,
     preferredTask: preferredSelection.task,
     preferredActivityLabel: preferredSelection.label,
-    remainingMs: state.activeSession
-      ? state.activeSession.status === "paused"
-        ? (state.activeSession.pausedRemainingMs ?? 0)
-        : Math.max(0, new Date(state.activeSession.endsAt).getTime() - nowMs)
-      : 0,
-    canCompleteNow,
     loading,
-    reload: async () => load({ preserveVisibleState: true }),
+    reload,
     startPomodoro,
     pauseCurrent,
     resumeCurrent,
@@ -336,5 +489,23 @@ export const usePomodoroController = (repository: AppRepository | null): Pomodor
     completeNow,
     cancelCurrent,
     switchTask
-  };
+  }), [
+    cancelCurrent,
+    completeCurrentTask,
+    completeNow,
+    currentActivityLabel,
+    currentTask,
+    loading,
+    pauseCurrent,
+    preferredSelection,
+    reload,
+    resumeCurrent,
+    sessions,
+    skipBreak,
+    startPomodoro,
+    state,
+    switchTask,
+    taskOptions,
+    taskSummaries
+  ]);
 };

--- a/src/app/use-pomodoro-timing.test.tsx
+++ b/src/app/use-pomodoro-timing.test.tsx
@@ -1,0 +1,26 @@
+import { act, renderHook } from "@testing-library/react";
+import { createPomodoroSession } from "../lib/pomodoro/engine";
+import { usePomodoroTiming } from "./use-pomodoro-timing";
+
+describe("usePomodoroTiming", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("ticks a valid running session locally and stops for paused or invalid data", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T09:00:00.000Z"));
+    const running = { ...createPomodoroSession("focus", "2026-04-01T09:00:00.000Z", 1), segments: [], activeTaskId: null, activeLabel: null, taskIds: [] };
+    const { result, rerender } = renderHook(({ session }) => usePomodoroTiming(session), { initialProps: { session: running } });
+
+    expect(result.current.remainingMs).toBe(25 * 60 * 1000);
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.remainingMs).toBe(25 * 60 * 1000 - 1000);
+
+    rerender({ session: { ...running, status: "paused" as const, pausedRemainingMs: 42_000 } });
+    act(() => vi.advanceTimersByTime(5_000));
+    expect(result.current).toMatchObject({ remainingMs: 42_000, valid: true });
+
+    rerender({ session: { ...running, endsAt: "invalid" } });
+    expect(result.current).toMatchObject({ remainingMs: 0, valid: false });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/app/use-pomodoro-timing.ts
+++ b/src/app/use-pomodoro-timing.ts
@@ -1,0 +1,22 @@
+import { useEffect, useMemo, useState } from "react";
+import type { PomodoroSessionDetails } from "../domain/types";
+import { getPomodoroTiming, type PomodoroTiming } from "../lib/pomodoro/engine";
+
+/** Local display clock for the two Pomodoro views; it never updates AppProvider state. */
+export const usePomodoroTiming = (session: PomodoroSessionDetails | null): PomodoroTiming => {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const timing = useMemo(() => getPomodoroTiming(session, nowMs), [nowMs, session]);
+
+  useEffect(() => {
+    setNowMs(Date.now());
+
+    if (!session || session.status !== "running" || !getPomodoroTiming(session, Date.now()).valid) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(intervalId);
+  }, [session?.endsAt, session?.id, session?.pausedRemainingMs, session?.status]);
+
+  return timing;
+};

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -25,7 +25,7 @@ const navigation = [
 
 export const AppShell = () => {
   const { pomodoro } = useAppContext();
-  const hasFloatingPomodoro = Boolean(pomodoro.state.activeSession && pomodoro.remainingMs > 0);
+  const hasFloatingPomodoro = Boolean(pomodoro.state.activeSession);
   const quoteOfTheDay = getQuoteOfTheDay();
 
   return (

--- a/src/components/FloatingPomodoroTimer.tsx
+++ b/src/components/FloatingPomodoroTimer.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { useAppContext } from "../app/app-context";
+import { usePomodoroTiming } from "../app/use-pomodoro-timing";
 import { formatTimerRemaining } from "../lib/date";
 import { getPomodoroKindLabel } from "../lib/pomodoro/engine";
 
@@ -9,9 +10,10 @@ const isBreakSession = (kind: "focus" | "short_break" | "long_break") =>
 export const FloatingPomodoroTimer = () => {
   const { pomodoro, debugEnabled } = useAppContext();
   const activeSession = pomodoro.state.activeSession;
-  const hasLiveSession = Boolean(activeSession && pomodoro.remainingMs > 0);
+  const timing = usePomodoroTiming(activeSession);
+  const hasActiveSession = Boolean(activeSession);
 
-  if (!hasLiveSession || !activeSession) {
+  if (!hasActiveSession || !activeSession) {
     return null;
   }
 
@@ -39,7 +41,7 @@ export const FloatingPomodoroTimer = () => {
       <div className="floating-pomodoro__body">
         <div className="floating-pomodoro__clock">
           <span className="floating-pomodoro__kind">{getPomodoroKindLabel(activeSession.kind)}</span>
-          <strong>{formatTimerRemaining(pomodoro.remainingMs)}</strong>
+          <strong>{timing.valid ? formatTimerRemaining(timing.remainingMs) : "--:--"}</strong>
         </div>
 
         <div className="floating-pomodoro__summary">
@@ -63,7 +65,7 @@ export const FloatingPomodoroTimer = () => {
           <button className="button" type="button" onClick={() => void pomodoro.skipBreak()}>
             Skipper
           </button>
-        ) : pomodoro.canCompleteNow ? (
+        ) : timing.canCompleteNow ? (
           <button className="button" type="button" onClick={() => void pomodoro.completeNow()}>
             Terminer
           </button>

--- a/src/lib/pomodoro/engine.test.ts
+++ b/src/lib/pomodoro/engine.test.ts
@@ -5,11 +5,63 @@ import {
   computeDailyPomodoroStats,
   createPomodoroSegment,
   createPomodoroSession,
+  getPomodoroTiming,
   getPomodoroRunningBreakSessionIdsToAutoCompleteWhenReset
 } from "./engine";
 import type { Task } from "../../domain/types";
 
 describe("pomodoro engine", () => {
+  it("calculates running and paused timing at the focus completion boundary", () => {
+    const running = createPomodoroSession("focus", "2026-04-01T09:00:00.000Z", 1);
+    const halfway = new Date("2026-04-01T09:12:30.000Z").getTime();
+
+    expect(getPomodoroTiming(running, halfway)).toEqual({
+      remainingMs: 12 * 60 * 1000 + 30 * 1000,
+      canCompleteNow: true,
+      valid: true
+    });
+    expect(getPomodoroTiming({ ...running, status: "paused", pausedRemainingMs: 30 * 60 * 1000 }, halfway + 999_999)).toEqual({
+      remainingMs: 25 * 60 * 1000,
+      canCompleteNow: false,
+      valid: true
+    });
+  });
+
+  it("rejects corrupt timing data and never permits break completion", () => {
+    const breakSession = createPomodoroSession("short_break", "2026-04-01T09:00:00.000Z", 1);
+
+    expect(getPomodoroTiming({ ...breakSession, endsAt: "not-a-date" }, Date.now())).toEqual({
+      remainingMs: 0,
+      canCompleteNow: false,
+      valid: false
+    });
+    expect(getPomodoroTiming({ ...breakSession, status: "paused", pausedRemainingMs: -1 }, Date.now())).toEqual({
+      remainingMs: 0,
+      canCompleteNow: false,
+      valid: false
+    });
+    expect(getPomodoroTiming(breakSession, new Date(breakSession.endsAt).getTime())).toEqual({
+      remainingMs: 0,
+      canCompleteNow: false,
+      valid: true
+    });
+  });
+
+  it("keeps a running session with a malformed deadline active for recovery", () => {
+    const corruptRunning = {
+      ...createPomodoroSession("focus", "2026-04-01T09:00:00.000Z", 1),
+      endsAt: "not-a-date"
+    };
+
+    const state = buildPomodoroState([corruptRunning], [], "2026-04-01T10:00:00.000Z");
+
+    expect(state.activeSession).toMatchObject({
+      id: corruptRunning.id,
+      status: "running",
+      endsAt: "not-a-date"
+    });
+  });
+
   it("chains focus sessions toward a long break after the fourth focus", () => {
     const sessions = [
       {

--- a/src/lib/pomodoro/engine.ts
+++ b/src/lib/pomodoro/engine.ts
@@ -23,6 +23,49 @@ export const clonePomodoroSegment = (segment: PomodoroSegment): PomodoroSegment 
 
 export const getPomodoroDurationMs = (kind: PomodoroKind): number => POMODORO_DURATIONS_MS[kind];
 
+export interface PomodoroTiming {
+  remainingMs: number;
+  canCompleteNow: boolean;
+  valid: boolean;
+}
+
+/**
+ * Calculates display/action timing without mutating a session. Paused sessions deliberately
+ * use their persisted remaining duration only, so opening a screen cannot advance a pause.
+ */
+export const getPomodoroTiming = (
+  session: Pick<PomodoroSession, "kind" | "status" | "endsAt" | "pausedRemainingMs"> | null,
+  nowMs: number
+): PomodoroTiming => {
+  if (!session) {
+    return { remainingMs: 0, canCompleteNow: false, valid: false };
+  }
+
+  const durationMs = getPomodoroDurationMs(session.kind);
+  let remainingMs: number;
+
+  if (session.status === "running") {
+    const endsAtMs = new Date(session.endsAt).getTime();
+    if (!Number.isFinite(endsAtMs) || !Number.isFinite(nowMs)) {
+      return { remainingMs: 0, canCompleteNow: false, valid: false };
+    }
+    remainingMs = Math.max(0, Math.min(durationMs, endsAtMs - nowMs));
+  } else if (session.status === "paused") {
+    if (!Number.isFinite(session.pausedRemainingMs) || (session.pausedRemainingMs ?? -1) < 0) {
+      return { remainingMs: 0, canCompleteNow: false, valid: false };
+    }
+    remainingMs = Math.min(durationMs, session.pausedRemainingMs as number);
+  } else {
+    return { remainingMs: 0, canCompleteNow: false, valid: false };
+  }
+
+  return {
+    remainingMs,
+    canCompleteNow: session.kind === "focus" && durationMs - remainingMs >= durationMs / 2,
+    valid: true
+  };
+};
+
 export const createPomodoroSession = (
   kind: PomodoroKind,
   startedAt: string,
@@ -99,14 +142,15 @@ const findLatestCompletedSession = (sessions: PomodoroSession[]): PomodoroSessio
   return completed.length > 0 ? completed[completed.length - 1] : null;
 };
 
-/** Sessions still marked running but past endsAt are treated as completed at endsAt so idle/reset logic applies. */
+/** Sessions still marked running with a valid, past endsAt are treated as completed at endsAt so idle/reset logic applies. */
 const normalizePomodoroSessionsForState = (sessions: PomodoroSession[], nowIso: string): PomodoroSession[] => {
   const nowMs = new Date(nowIso).getTime();
   return sessions.map((session) => {
     if (session.status !== "running") {
       return session;
     }
-    if (new Date(session.endsAt).getTime() > nowMs) {
+    const endsAtMs = new Date(session.endsAt).getTime();
+    if (!Number.isFinite(endsAtMs) || !Number.isFinite(nowMs) || endsAtMs > nowMs) {
       return session;
     }
     return {
@@ -143,6 +187,13 @@ const findLastSessionActivityAt = (sessions: PomodoroSession[]): string | null =
  */
 const shouldResetPomodoroCycleAfterIdle = (sessions: PomodoroSession[], nowIso: string): boolean => {
   if (sessions.some((session) => session.status === "paused")) {
+    return false;
+  }
+
+  // A malformed running deadline must stay visible so the controller can offer recovery
+  // actions. Treating it as an expired completion here would only change memory, leaving
+  // the persisted row running.
+  if (sessions.some((session) => session.status === "running" && !Number.isFinite(new Date(session.endsAt).getTime()))) {
     return false;
   }
 

--- a/src/pages/PomodoroPage.tsx
+++ b/src/pages/PomodoroPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAppContext } from "../app/app-context";
+import { usePomodoroTiming } from "../app/use-pomodoro-timing";
 import { SectionCard } from "../components/SectionCard";
 import { formatDateLong, formatDateTimeShort, formatSecondsCompact, formatTimerRemaining, getTodayDate } from "../lib/date";
 import { getPomodoroKindLabel } from "../lib/pomodoro/engine";
@@ -45,7 +46,8 @@ export const PomodoroPage = () => {
   ]);
 
   const activeSession = pomodoro.state.activeSession;
-  const hasActiveSession = Boolean(activeSession && pomodoro.remainingMs > 0);
+  const timing = usePomodoroTiming(activeSession);
+  const hasActiveSession = Boolean(activeSession);
   const hasRunningSession = Boolean(hasActiveSession && activeSession?.status === "running");
   const hasPausedSession = Boolean(hasActiveSession && activeSession?.status === "paused");
   const hasLiveFocusSession = Boolean(hasRunningSession && activeSession?.kind === "focus");
@@ -81,7 +83,7 @@ export const PomodoroPage = () => {
         <div className="pomodoro-panel">
           <div className={`pomodoro-clock${activeSession ? ` pomodoro-clock--${activeSession.kind}` : ""}`}>
             <span className="pomodoro-clock__label">{sessionLabel}</span>
-            <strong>{hasActiveSession && activeSession ? formatTimerRemaining(pomodoro.remainingMs) : "00:00"}</strong>
+            <strong>{hasActiveSession && activeSession ? timing.valid ? formatTimerRemaining(timing.remainingMs) : "--:--" : "00:00"}</strong>
             <span className="pomodoro-clock__cycle">
               Session {pomodoro.state.currentCycleIndex}/4{hasPausedSession ? " • En pause" : ""}
             </span>
@@ -205,21 +207,15 @@ export const PomodoroPage = () => {
                 </button>
               ) : null}
 
-              {(hasLiveFocusSession || hasPausedFocusSession) && pomodoro.canCompleteNow ? (
+              {(hasLiveFocusSession || hasPausedFocusSession) ? (
                 <>
-                  <button className="button" type="button" onClick={() => void pomodoro.completeNow()}>
+                  <button className="button" type="button" disabled={!timing.canCompleteNow} onClick={() => void pomodoro.completeNow()}>
                     Terminer maintenant
                   </button>
                   <button className="button button--ghost" type="button" onClick={() => void pomodoro.cancelCurrent()}>
                     Annuler la session
                   </button>
                 </>
-              ) : null}
-
-              {(hasLiveFocusSession || hasPausedFocusSession) && !pomodoro.canCompleteNow ? (
-                <button className="button button--ghost" type="button" onClick={() => void pomodoro.cancelCurrent()}>
-                  Annuler la session
-                </button>
               ) : null}
 
               {(hasLiveBreakSession || hasPausedBreakSession) ? (
@@ -234,9 +230,9 @@ export const PomodoroPage = () => {
                 {hasPausedSession
                   ? "La session est en pause. Reprendre relance le chrono la ou il s'est arrete."
                   : hasLiveFocusSession
-                    ? pomodoro.canCompleteNow
+                    ? timing.canCompleteNow
                       ? "Terminer maintenant cloture cette session comme completee et fait avancer le cycle. Annuler la session l'arrete sans la compter comme accomplie."
-                      : "Pendant la premiere moitie du focus, tu peux mettre en pause ou annuler la session. Terminer maintenant apparait apres la moitie du pomodoro."
+                      : "Pendant la premiere moitie du focus, tu peux mettre en pause ou annuler la session. Terminer maintenant est active apres la moitie du pomodoro."
                     : "Skipper la pause cloture la pause tout de suite et relance le cycle. Annuler la session l'arrete sans la compter."}
               </p>
             ) : null}

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -43,8 +43,6 @@ export const renderWithApp = async (
       currentActivityLabel: null,
       preferredTask: null,
       preferredActivityLabel: null,
-      remainingMs: 0,
-      canCompleteNow: false,
       loading: false,
       reload: async () => undefined,
       startPomodoro: async () => undefined,


### PR DESCRIPTION
## Summary
- move one-second Pomodoro display timing out of global app context
- add serialized deadline expiry scheduling and stale-safe controller refreshes
- cover invalid deadlines and expiry races with focused tests

Reviewed through the develop-review workflow: approved after 1 fix/review cycle.

## Verification
- npm run test
- npm run build