### PR TITLE
Fold calories and RescueTime pulse into weekly score

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Optional: local dev scripts only (scripts/rescuetime-*.mjs).
+# The bundled desktop app never reads this file — configure the key in
+# Parametres → RescueTime inside TrackDidia instead.
+RESCUETIME_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 dist
+.env
+.env.*
+!.env.example
 .DS_Store
 coverage
 src-tauri/target

--- a/docs/ai-settings-and-privacy.md
+++ b/docs/ai-settings-and-privacy.md
@@ -18,6 +18,7 @@ Default highlights:
 | AI enabled | No |
 | AI base URL | `https://openrouter.ai/api/v1` |
 | AI model | `moonshotai/kimi-k2.6` |
+| RescueTime API key | Empty |
 | Automatic backup | Enabled, 24 hours |
 | Relationship draws | Enabled |
 
@@ -93,6 +94,35 @@ Headers include the bearer API key, `HTTP-Referer: https://trackdidia.app`, and
 Only `choices[0].message.content` string responses are supported. HTTP/provider
 errors produce a fallback local message plus a visible warning; they do not block
 the daily workflow.
+
+## RescueTime request
+
+The weekly review loads **RescueTime Goals** when a non-empty `rescuetimeApiKey`
+is stored in app settings. The bundled desktop app reads this key **only** from
+SQLite settings (`Parametres → RescueTime`); it never reads a repo-root `.env` file.
+
+Requests use browser `fetch()` from the webview layer (same pattern as OpenRouter):
+
+```text
+GET https://www.rescuetime.com/api/resource/goals
+Authorization: Bearer {rescuetimeApiKey}
+
+GET https://www.rescuetime.com/anapi/data
+  ?format=json
+  &perspective=rank
+  &restrict_kind={overview|productivity|...}
+  &restrict_begin={weekStartDate}
+  &restrict_end={weekEndDate}
+Authorization: Bearer {rescuetimeApiKey}
+```
+
+The key is stored locally in the singleton `app_settings` row, merged with defaults
+on read, and included in SQLite backups. It is never logged by the app. You can
+change it at any time while the app is running; the weekly review reloads goals
+when the saved key changes.
+
+Repo-root `.env` with `RESCUETIME_API_KEY` is optional and supported **only** for
+local CLI scripts such as `scripts/rescuetime-goals-score.mjs`.
 
 ## Privacy implications
 

--- a/docs/ai-settings-and-privacy.md
+++ b/docs/ai-settings-and-privacy.md
@@ -101,7 +101,12 @@ The weekly review loads **RescueTime Goals** when a non-empty `rescuetimeApiKey`
 is stored in app settings. The bundled desktop app reads this key **only** from
 SQLite settings (`Parametres → RescueTime`); it never reads a repo-root `.env` file.
 
-Requests use browser `fetch()` from the webview layer (same pattern as OpenRouter):
+RescueTime HTTP uses dual transport via `fetchRescueTimeJson`:
+
+- **Tauri desktop:** native `rescuetime_http_get` (Rust host) to avoid webview CORS limits.
+- **Browser preview / non-Tauri:** browser `fetch()` with `Authorization: Bearer` (same pattern as OpenRouter).
+
+Both paths call the same RescueTime endpoints:
 
 ```text
 GET https://www.rescuetime.com/api/resource/goals

--- a/docs/ai-settings-and-privacy.md
+++ b/docs/ai-settings-and-privacy.md
@@ -121,6 +121,10 @@ GET https://www.rescuetime.com/anapi/data
 Authorization: Bearer {rescuetimeApiKey}
 ```
 
+The weekly review also fetches a **productivity pulse** with
+`restrict_kind=productivity` and no `restrict_schedule_id` (full-week computer
+time, Sunday–Saturday).
+
 The key is stored locally in the singleton `app_settings` row, merged with defaults
 on read, and included in SQLite backups. It is never logged by the app. You can
 change it at any time while the app is running; the weekly review reloads goals

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,7 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-08-12 | Weekly score: seven local axes (calories at 3800 kcal/day), optional RescueTime Goals + productivity pulse overlay on `/semaine` | `docs/reviews-and-goals.md`, `docs/ai-settings-and-privacy.md` | `src/domain/weekly-review.ts`, `src/lib/rescuetime/rescuetime-goals-service.ts`, weekly review page |
 | 2026-08-11 | Documented RescueTime dual transport (Tauri native HTTP vs browser fetch fallback) | `docs/ai-settings-and-privacy.md` | `fetchRescueTimeJson`, `rescuetime_http_get` |
 | 2026-08-11 | Clarified RescueTime API key is app settings only at runtime; Settings test uses Goals API; weekly review reloads on key change | `docs/ai-settings-and-privacy.md`, `docs/reviews-and-goals.md` | Settings page, `RescueTimeGoalsService.testConnection`, weekly review effect |
 | 2026-08-11 | Added standing weekly objectives with RescueTime time scoring, migration 20, settings key, and `/semaine` UI | `docs/reviews-and-goals.md`, `docs/ai-settings-and-privacy.md`, `docs/storage-and-backups.md` | Migration 20, `src/domain/weekly-objectives.ts`, `src/lib/rescuetime/*`, weekly review page |

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,8 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-08-11 | Clarified RescueTime API key is app settings only at runtime; Settings test uses Goals API; weekly review reloads on key change | `docs/ai-settings-and-privacy.md`, `docs/reviews-and-goals.md` | Settings page, `RescueTimeGoalsService.testConnection`, weekly review effect |
+| 2026-08-11 | Added standing weekly objectives with RescueTime time scoring, migration 20, settings key, and `/semaine` UI | `docs/reviews-and-goals.md`, `docs/ai-settings-and-privacy.md`, `docs/storage-and-backups.md` | Migration 20, `src/domain/weekly-objectives.ts`, `src/lib/rescuetime/*`, weekly review page |
 | 2026-07-29 | Bootstrapped the full agent-maintained documentation system: architecture, persistence, daily routines, reviews/goals, GTD, recurrences/Pomodoro, AI/privacy, conventions, and desktop builds | `AGENTS.md`, `docs/*.md` | Current source tree, tests, Tauri configuration, comparison with the Bâtisseurs documentation structure |
 
 ## Entry template

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,7 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-08-11 | Documented RescueTime dual transport (Tauri native HTTP vs browser fetch fallback) | `docs/ai-settings-and-privacy.md` | `fetchRescueTimeJson`, `rescuetime_http_get` |
 | 2026-08-11 | Clarified RescueTime API key is app settings only at runtime; Settings test uses Goals API; weekly review reloads on key change | `docs/ai-settings-and-privacy.md`, `docs/reviews-and-goals.md` | Settings page, `RescueTimeGoalsService.testConnection`, weekly review effect |
 | 2026-08-11 | Added standing weekly objectives with RescueTime time scoring, migration 20, settings key, and `/semaine` UI | `docs/reviews-and-goals.md`, `docs/ai-settings-and-privacy.md`, `docs/storage-and-backups.md` | Migration 20, `src/domain/weekly-objectives.ts`, `src/lib/rescuetime/*`, weekly review page |
 | 2026-07-29 | Bootstrapped the full agent-maintained documentation system: architecture, persistence, daily routines, reviews/goals, GTD, recurrences/Pomodoro, AI/privacy, conventions, and desktop builds | `AGENTS.md`, `docs/*.md` | Current source tree, tests, Tauri configuration, comparison with the Bâtisseurs documentation structure |

--- a/docs/reviews-and-goals.md
+++ b/docs/reviews-and-goals.md
@@ -53,6 +53,7 @@ Each day contributes:
 - whether TRC is exactly `true`;
 - phone screen minutes;
 - Pomodoro count;
+- calorie expenditure;
 - discipline fraction;
 - tasks added;
 - tasks completed.
@@ -70,27 +71,43 @@ Explicit daily metrics override suggested GTD/Pomodoro values.
 | Discipline | Average of seven daily discipline fractions |
 | Tasks added/completed | Sum of daily values |
 | Task completion rate | Completed / added; zero when added is zero |
+| Calorie average | Mean of seven daily values (null → 0) |
+| Physical activity axis | `(calorieAverage * 100) / 3800`, lower-clamped |
 
-The automatic score has six axes:
+The automatic score has **seven local axes** (used by monthly and annual summaries):
 
 1. Sleep quality against 100.
 2. TRC percentage against 100.
 3. Phone screen axis, where 840 weekly minutes is 100, zero minutes is 200, and
    1,680 minutes is zero (lower-clamped, not upper-clamped).
-4. Pomodoro axis, where 56 weekly sessions is 100.
+4. Focus time (Pomodoro) axis, where 56 weekly sessions is 100.
 5. Discipline percentage against 100.
 6. Task completion percentage against 100.
+7. Physical activity axis against 3,800 kcal/day average.
 
 Each axis is passed through `scoreAgainstTarget(value, 100)`. Values through the
 target scale linearly from zero to one; above-target performance continues at half
-the rate. `weeklyScore` is the mean of those six normalized axis values and can
-therefore exceed `1` (100%).
+the rate. Repository `weeklyScore` is the mean of those seven normalized axis values
+and can therefore exceed `1` (100%).
+
+On `/semaine`, two optional **RescueTime axes** overlay the score when data is
+available (non-null):
+
+8. RescueTime Goals score (`0–1` from enabled goals).
+9. Computer productivity pulse (`0–100`, time-weighted from Analytic Data).
+
+`applyWeeklyScoreExternalAxes()` recomputes the displayed weekly score as the mean
+of the seven local axes plus each non-null RescueTime axis. Stale RescueTime
+snapshots from a different week are ignored until the matching week loads. Monthly
+`weeklyScoreAverage` and annual `weekly_weekly_score` use the seven-axis local score
+only (calories included; RescueTime excluded).
 
 ### Weekly objectives (RescueTime Goals)
 
-The `/semaine` screen loads **enabled RescueTime Goals** from the Resource API and
-scores them for the selected Sunday–Saturday week. This score is separate from the
-six-axis `weeklyScore` above.
+The `/semaine` screen loads **enabled RescueTime Goals** and a **productivity pulse**
+from the Analytic Data API for the selected Sunday–Saturday week. These scores feed
+the optional RescueTime axes above; they are not persisted and are not part of the
+repository weekly summary.
 
 Each goal is worth at most **1 point**:
 
@@ -108,6 +125,26 @@ score = sum(achievement) / count(goals)
 ```
 
 When there are no enabled goals, the score displays `—` (null), not `0%`.
+
+### Computer productivity pulse
+
+The weekly pulse uses Analytic Data with `restrict_kind=productivity` (no
+`restrict_schedule_id`):
+
+```text
+GET anapi/data?format=json&perspective=rank&restrict_kind=productivity
+  &restrict_begin={Sunday}&restrict_end={Saturday}
+```
+
+RescueTime productivity levels (`-2`..`+2`) are time-weighted:
+
+```text
+mean = sum(productivityLevel * seconds) / sum(seconds)
+pulse = ((mean + 2) / 4) * 100
+```
+
+When there is no tracked computer time (`sum(seconds) === 0`), the pulse is `null`
+and excluded from the displayed weekly score. A real `0` pulse is included.
 
 Goals are read-only in TrackDidia — manage them in RescueTime. Configure the API key
 under **Parametres → RescueTime** (stored in SQLite, same as OpenRouter). Time data

--- a/docs/reviews-and-goals.md
+++ b/docs/reviews-and-goals.md
@@ -86,6 +86,35 @@ target scale linearly from zero to one; above-target performance continues at ha
 the rate. `weeklyScore` is the mean of those six normalized axis values and can
 therefore exceed `1` (100%).
 
+### Weekly objectives (RescueTime Goals)
+
+The `/semaine` screen loads **enabled RescueTime Goals** from the Resource API and
+scores them for the selected Sunday–Saturday week. This score is separate from the
+six-axis `weeklyScore` above.
+
+Each goal is worth at most **1 point**:
+
+| Direction | Achievement |
+|---|---|
+| More time | `min(actualHours / weeklyTargetHours, 1)` |
+| Less time | `1` when under the weekly cap; otherwise `weeklyTargetHours / actualHours` |
+
+Weekly target hours come from the goal's daily `amount_seconds` multiplied by the
+number of days implied by the goal schedule (`7` for 24x7, `5` for working/weekday
+schedules).
+
+```text
+score = sum(achievement) / count(goals)
+```
+
+When there are no enabled goals, the score displays `—` (null), not `0%`.
+
+Goals are read-only in TrackDidia — manage them in RescueTime. Configure the API key
+under **Parametres → RescueTime** (stored in SQLite, same as OpenRouter). Time data
+comes from the Analytic Data API and labeled project times (projects and clients).
+Schedule windows such as “Evening family time” are not filtered yet; v1 uses full-week
+totals with a documented approximation.
+
 ## Monthly review (`/mois`)
 
 ### Calendar model

--- a/docs/storage-and-backups.md
+++ b/docs/storage-and-backups.md
@@ -98,6 +98,7 @@ Never renumber or rewrite a released migration. Add the next ID.
 | 17 | `create_monthly_reviews` | Monthly ritual state |
 | 18 | `create_annual_goals` | Goals and monthly evaluations |
 | 19 | `add_paused_remaining_ms_to_pomodoro_sessions` | Durable paused timer state |
+| 20 | `create_weekly_objectives` | Standing weekly objectives and per-week manual results |
 
 ## Table reference
 
@@ -215,6 +216,8 @@ Each row is one contiguous activity slice within a session: `session_id`, option
 ### Review and goal tables
 
 - `weekly_reviews`: Sunday start, Saturday end, status, notes JSON, checklist JSON.
+- `weekly_objectives`: standing objective definitions (`kind`, optional RescueTime mapping, target hours, sort order).
+- `weekly_objective_results`: per-week manual achievement (`achieved` 0/1) keyed by `(week_start_date, objective_id)` with `ON DELETE CASCADE` from objectives.
 - `monthly_reviews`: month key/start/end, status, notes JSON, checklist JSON.
 - `annual_goals`: target/source/manual value plus evaluations JSON keyed by month.
 
@@ -262,7 +265,7 @@ code task.
 
 - The database contains personal journals, principles, goals, tasks, and AI
   configuration.
-- `app_settings.value` may contain the OpenRouter API key in plaintext.
+- `app_settings.value` may contain the OpenRouter API key and the RescueTime API key in plaintext.
 - Backups contain the same sensitive data as the source database.
 - `Tasks.json` may contain personal Google Tasks data and is intentionally
   gitignored.

--- a/scripts/rescuetime-goals-score.mjs
+++ b/scripts/rescuetime-goals-score.mjs
@@ -45,11 +45,12 @@ const addDays = (dateText, days) => {
 
 const scheduleDaysInWeek = (scheduleName) => {
   const normalized = (scheduleName ?? "").toLowerCase();
-  if (normalized.includes("working") || normalized.includes("weekday")) {
+  if (
+    normalized.includes("working") ||
+    normalized.includes("weekday") ||
+    normalized.includes("work hour")
+  ) {
     return 5;
-  }
-  if (normalized.includes("evening")) {
-    return 7;
   }
   return 7;
 };
@@ -113,34 +114,50 @@ class RescueTimeGoalsClient {
     return goals.filter((goal) => goal.enabled !== false);
   }
 
-  async fetchAnalyticRank(kind, begin, end) {
+  async fetchAnalyticRank(kind, begin, end, scheduleId = 0) {
     const url = new URL("https://www.rescuetime.com/anapi/data");
     url.searchParams.set("format", "json");
     url.searchParams.set("perspective", "rank");
     url.searchParams.set("restrict_kind", kind);
     url.searchParams.set("restrict_begin", begin);
     url.searchParams.set("restrict_end", end);
+    if (scheduleId > 0) {
+      url.searchParams.set("restrict_schedule_id", String(scheduleId));
+    }
     return this.fetchJson(url);
   }
 
   async fetchProjectTimesByName(begin, end) {
-    const url = new URL("https://www.rescuetime.com/api/resource/labeled_time_project_times");
-    url.searchParams.set("start_date", begin);
-    url.searchParams.set("end_date", end);
-    const payload = await this.fetchJson(url);
     const byName = new Map();
     const byClientId = new Map();
-    for (const entry of payload.project_times ?? []) {
-      const projectName = normalizeLabel(entry.project?.name ?? "");
-      const clientId = entry.project?.timesheets_client_id;
-      const duration = Number(entry.duration ?? 0);
-      if (projectName) {
-        byName.set(projectName, (byName.get(projectName) ?? 0) + duration);
-      }
-      if (clientId) {
-        byClientId.set(clientId, (byClientId.get(clientId) ?? 0) + duration);
+
+    for (let cursor = begin; cursor <= end; cursor = addDays(cursor, 1)) {
+      const url = new URL("https://www.rescuetime.com/api/resource/labeled_time_project_times");
+      url.searchParams.set("date", cursor);
+
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        const payload = await this.fetchJson(url);
+        if (payload.is_complete !== false) {
+          for (const entry of payload.project_times ?? []) {
+            const projectName = normalizeLabel(entry.project?.name ?? "");
+            const clientId = entry.project?.timesheets_client_id;
+            const duration = Number(entry.duration ?? 0);
+            if (projectName) {
+              byName.set(projectName, (byName.get(projectName) ?? 0) + duration);
+            }
+            if (clientId) {
+              byClientId.set(clientId, (byClientId.get(clientId) ?? 0) + duration);
+            }
+          }
+          break;
+        }
+        if (attempt === 11) {
+          throw new Error(`RescueTime project times query did not complete for ${cursor}.`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500));
       }
     }
+
     return { byName, byClientId };
   }
 }
@@ -161,16 +178,42 @@ const labelsMatch = (left, right) => {
 };
 
 const productivitySecondsForGoal = (rows, goal) => {
-  const productivityId = goal.productivity?.id ?? goal.taxon_id;
+  const productivity = goal.productivity;
+  const productivityId = productivity?.id ?? goal.taxon_id;
+
   if (productivityId === 7) {
     return rows.filter((row) => row.productivity < 0).reduce((sum, row) => sum + row.seconds, 0);
   }
   if (productivityId === 10) {
     return rows.reduce((sum, row) => sum + row.seconds, 0);
   }
-  const needle = productivityNameForGoal(goal);
-  const row = rows.find((item) => item.name.includes(needle) || needle.includes(item.name));
-  return row?.seconds ?? 0;
+
+  const sqlEquals = (productivity?.sql_score_equals ?? "").toLowerCase();
+  if (sqlEquals.includes("< 0")) {
+    return rows.filter((row) => row.productivity < 0).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (sqlEquals.includes("between -2 and 2")) {
+    return rows.reduce((sum, row) => sum + row.seconds, 0);
+  }
+
+  const name = (productivity?.name ?? productivity?.display_name ?? "").toLowerCase();
+  if (name.includes("very productive") || name.includes("focus work")) {
+    return rows.filter((row) => row.productivity === 2).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (name.includes("other work") || (name.includes("productive") && !name.includes("distracting"))) {
+    return rows.filter((row) => row.productivity === 1).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (name.includes("neutral")) {
+    return rows.filter((row) => row.productivity === 0).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (name.includes("very distracting")) {
+    return rows.filter((row) => row.productivity === -2).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (name.includes("personal") || name.includes("distracting")) {
+    return rows.filter((row) => row.productivity === -1).reduce((sum, row) => sum + row.seconds, 0);
+  }
+
+  return rows.filter((row) => row.productivity === productivityId).reduce((sum, row) => sum + row.seconds, 0);
 };
 
 const overviewNameForGoal = (goal) => (goal.overview?.name ?? goal.taxon_display_name ?? "").toLowerCase();

--- a/scripts/rescuetime-goals-score.mjs
+++ b/scripts/rescuetime-goals-score.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Score weekly objectives from RescueTime Goals (Resource API + time data).
+ *
+ * Usage: node scripts/rescuetime-goals-score.mjs [--week YYYY-MM-DD]
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+
+const loadEnvFile = () => {
+  try {
+    const raw = readFileSync(join(repoRoot, ".env"), "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      const value = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+      if (!(key in process.env)) process.env[key] = value;
+    }
+  } catch {
+    // optional
+  }
+};
+
+loadEnvFile();
+
+const getWeekStartSunday = (dateText) => {
+  const date = new Date(`${dateText}T12:00:00`);
+  date.setDate(date.getDate() - date.getDay());
+  return date.toISOString().slice(0, 10);
+};
+
+const addDays = (dateText, days) => {
+  const date = new Date(`${dateText}T12:00:00`);
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+};
+
+const scheduleDaysInWeek = (scheduleName) => {
+  const normalized = (scheduleName ?? "").toLowerCase();
+  if (normalized.includes("working") || normalized.includes("weekday")) {
+    return 5;
+  }
+  if (normalized.includes("evening")) {
+    return 7;
+  }
+  return 7;
+};
+
+const scoreMoreGoal = (actualSeconds, targetSeconds) => {
+  if (targetSeconds <= 0) return 0;
+  return Math.min(Math.max(0, actualSeconds) / targetSeconds, 1);
+};
+
+const scoreLessGoal = (actualSeconds, targetSeconds) => {
+  if (targetSeconds <= 0) return 0;
+  const actual = Math.max(0, actualSeconds);
+  if (actual <= targetSeconds) return 1;
+  return Math.min(targetSeconds / actual, 1);
+};
+
+const findSecondsColumnIndex = (rowHeaders) => {
+  const normalized = rowHeaders.map((header) => String(header).toLowerCase());
+  return normalized.findIndex((header) => header.includes("time spent"));
+};
+
+const findNameColumnIndex = (rowHeaders, kind) => {
+  const normalized = rowHeaders.map((header) => String(header).toLowerCase());
+  if (kind === "productivity") {
+    const productivityIndex = normalized.findIndex((header) => header.includes("productivity"));
+    if (productivityIndex >= 0) return productivityIndex;
+  }
+  const categoryIndex = normalized.findIndex((header) => header === "category" || header.includes("overview"));
+  if (categoryIndex >= 0) return categoryIndex;
+  return normalized.length > 1 ? normalized.length - 1 : 1;
+};
+
+const parseRankRows = (payload, kind) => {
+  const headers = payload.row_headers ?? [];
+  const secondsIndex = findSecondsColumnIndex(headers);
+  const nameIndex = findNameColumnIndex(headers, kind);
+  return (payload.rows ?? []).map((row) => ({
+    name: String(row[nameIndex] ?? "").toLowerCase(),
+    productivity: kind === "productivity" ? Number(row[nameIndex] ?? 0) : null,
+    seconds: Number(row[secondsIndex] ?? 0)
+  }));
+};
+
+class RescueTimeGoalsClient {
+  constructor(apiKey) {
+    this.apiKey = apiKey;
+    this.headers = { Authorization: `Bearer ${apiKey}` };
+  }
+
+  async fetchJson(url, options = {}) {
+    const response = await fetch(url, { ...options, headers: { ...this.headers, ...options.headers } });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`${url} → ${response.status}: ${body.slice(0, 200)}`);
+    }
+    return response.json();
+  }
+
+  async listGoals() {
+    const goals = await this.fetchJson("https://www.rescuetime.com/api/resource/goals");
+    return goals.filter((goal) => goal.enabled !== false);
+  }
+
+  async fetchAnalyticRank(kind, begin, end) {
+    const url = new URL("https://www.rescuetime.com/anapi/data");
+    url.searchParams.set("format", "json");
+    url.searchParams.set("perspective", "rank");
+    url.searchParams.set("restrict_kind", kind);
+    url.searchParams.set("restrict_begin", begin);
+    url.searchParams.set("restrict_end", end);
+    return this.fetchJson(url);
+  }
+
+  async fetchProjectTimesByName(begin, end) {
+    const url = new URL("https://www.rescuetime.com/api/resource/labeled_time_project_times");
+    url.searchParams.set("start_date", begin);
+    url.searchParams.set("end_date", end);
+    const payload = await this.fetchJson(url);
+    const byName = new Map();
+    const byClientId = new Map();
+    for (const entry of payload.project_times ?? []) {
+      const projectName = normalizeLabel(entry.project?.name ?? "");
+      const clientId = entry.project?.timesheets_client_id;
+      const duration = Number(entry.duration ?? 0);
+      if (projectName) {
+        byName.set(projectName, (byName.get(projectName) ?? 0) + duration);
+      }
+      if (clientId) {
+        byClientId.set(clientId, (byClientId.get(clientId) ?? 0) + duration);
+      }
+    }
+    return { byName, byClientId };
+  }
+}
+
+const normalizeLabel = (value) =>
+  value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+const labelsMatch = (left, right) => {
+  const a = normalizeLabel(left);
+  const b = normalizeLabel(right);
+  if (!a || !b) return false;
+  return a.includes(b) || b.includes(a) || a.split(" ").some((token) => token.length > 3 && b.includes(token));
+};
+
+const productivitySecondsForGoal = (rows, goal) => {
+  const productivityId = goal.productivity?.id ?? goal.taxon_id;
+  if (productivityId === 7) {
+    return rows.filter((row) => row.productivity < 0).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (productivityId === 10) {
+    return rows.reduce((sum, row) => sum + row.seconds, 0);
+  }
+  const needle = productivityNameForGoal(goal);
+  const row = rows.find((item) => item.name.includes(needle) || needle.includes(item.name));
+  return row?.seconds ?? 0;
+};
+
+const overviewNameForGoal = (goal) => (goal.overview?.name ?? goal.taxon_display_name ?? "").toLowerCase();
+
+const resolveActualSeconds = async (client, goal, weekStart, weekEnd, caches) => {
+  const taxonomy = goal.taxonomy?.search_name ?? goal.taxonomy_name ?? "";
+
+  if (taxonomy === "projects" || goal.v2project) {
+    const projectTimes =
+      caches.projectTimes ?? (caches.projectTimes = await client.fetchProjectTimesByName(weekStart, weekEnd));
+    const label = goal.v2project?.name ?? goal.taxon_display_name ?? "";
+    for (const [name, seconds] of projectTimes.byName) {
+      if (labelsMatch(name, label)) {
+        return seconds;
+      }
+    }
+    return 0;
+  }
+
+  if (taxonomy === "clients") {
+    const projectTimes =
+      caches.projectTimes ?? (caches.projectTimes = await client.fetchProjectTimesByName(weekStart, weekEnd));
+    return projectTimes.byClientId.get(goal.taxon_id) ?? 0;
+  }
+
+  if (taxonomy === "productivity") {
+    const cacheKey = "productivity";
+    if (!caches[cacheKey]) {
+      caches[cacheKey] = parseRankRows(await client.fetchAnalyticRank("productivity", weekStart, weekEnd), "productivity");
+    }
+    return productivitySecondsForGoal(caches[cacheKey], goal);
+  }
+
+  if (taxonomy === "category" || taxonomy === "overviews" || goal.overview) {
+    const cacheKey = "overview";
+    if (!caches[cacheKey]) {
+      caches[cacheKey] = parseRankRows(await client.fetchAnalyticRank("overview", weekStart, weekEnd), "overview");
+    }
+    const needle = overviewNameForGoal(goal);
+    const row = caches[cacheKey].find((item) => item.name === needle || item.name.includes(needle));
+    return row?.seconds ?? 0;
+  }
+
+  return 0;
+};
+
+const main = async () => {
+  const apiKey = process.env.RESCUETIME_API_KEY?.trim();
+  if (!apiKey) {
+    console.error("Missing RESCUETIME_API_KEY");
+    process.exit(1);
+  }
+
+  const weekArg = process.argv.includes("--week") ? process.argv[process.argv.indexOf("--week") + 1] : null;
+  const weekStart = getWeekStartSunday(weekArg ?? new Date().toISOString().slice(0, 10));
+  const weekEnd = addDays(weekStart, 6);
+
+  const client = new RescueTimeGoalsClient(apiKey);
+  const goals = await client.listGoals();
+  const caches = {};
+  const results = [];
+
+  for (const goal of goals) {
+    const days = scheduleDaysInWeek(goal.schedule?.name ?? goal.schedule_name);
+    const dailyTargetSeconds = Number(goal.amount_seconds ?? 0);
+    const weeklyTargetSeconds = dailyTargetSeconds * days;
+    const actualSeconds = await resolveActualSeconds(client, goal, weekStart, weekEnd, caches);
+    const achievement = goal.is_more
+      ? scoreMoreGoal(actualSeconds, weeklyTargetSeconds)
+      : scoreLessGoal(actualSeconds, weeklyTargetSeconds);
+
+    results.push({
+      displayName: goal.display_name,
+      isMore: goal.is_more,
+      actualHours: actualSeconds / 3600,
+      weeklyTargetHours: weeklyTargetSeconds / 3600,
+      achievement,
+      schedule: goal.schedule?.name ?? goal.schedule_name ?? "24x7",
+      days
+    });
+  }
+
+  const totalAchievement = results.reduce((sum, item) => sum + item.achievement, 0);
+  const scorePercent = (totalAchievement / results.length) * 100;
+
+  console.log(`RescueTime Goals — week ${weekStart} → ${weekEnd}\n`);
+  for (const item of results) {
+    console.log(
+      `${item.displayName}\n` +
+        `  actual: ${item.actualHours.toFixed(2)}h / weekly target: ${item.weeklyTargetHours.toFixed(2)}h (${item.days}d × daily) → ${item.achievement.toFixed(2)}/1\n`
+    );
+  }
+
+  console.log(`Weekly objectives score: ${totalAchievement.toFixed(2)} / ${results.length} = ${scorePercent.toFixed(1)}%`);
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/rescuetime-poc.mjs
+++ b/scripts/rescuetime-poc.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * RescueTime proof-of-concept: fetch weekly category time and score objectives.
+ *
+ * Usage:
+ *   node scripts/rescuetime-poc.mjs --week 2026-08-03
+ *   node scripts/rescuetime-poc.mjs --week 2026-08-03 --list category
+ *   node scripts/rescuetime-poc.mjs --week 2026-08-03 --objective "Software Development:2"
+ *
+ * Reads RESCUETIME_API_KEY from environment or repo-root .env (never printed).
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+
+const loadEnvFile = () => {
+  try {
+    const raw = readFileSync(join(repoRoot, ".env"), "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) {
+        continue;
+      }
+      const eq = trimmed.indexOf("=");
+      if (eq <= 0) {
+        continue;
+      }
+      const key = trimmed.slice(0, eq).trim();
+      const value = trimmed.slice(eq + 1).trim().replace(/^["']|["']$/g, "");
+      if (!(key in process.env)) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // .env optional when key is already in environment
+  }
+};
+
+loadEnvFile();
+
+const parseArgs = () => {
+  const args = process.argv.slice(2);
+  const options = {
+    week: null,
+    listKind: null,
+    objectives: []
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--week" && args[index + 1]) {
+      options.week = args[++index];
+    } else if (arg === "--list" && args[index + 1]) {
+      options.listKind = args[++index];
+    } else if (arg === "--objective" && args[index + 1]) {
+      options.objectives.push(args[++index]);
+    }
+  }
+
+  return options;
+};
+
+const getWeekStartSunday = (dateText) => {
+  const date = new Date(`${dateText}T12:00:00`);
+  const day = date.getDay();
+  date.setDate(date.getDate() - day);
+  return date.toISOString().slice(0, 10);
+};
+
+const addDays = (dateText, days) => {
+  const date = new Date(`${dateText}T12:00:00`);
+  date.setDate(date.getDate() + days);
+  return date.toISOString().slice(0, 10);
+};
+
+const findSecondsColumnIndex = (rowHeaders) => {
+  const normalized = rowHeaders.map((header) => String(header).toLowerCase());
+  const candidates = ["time spent (seconds)", "time spent", "seconds", "time_spent_seconds"];
+  for (const candidate of candidates) {
+    const index = normalized.findIndex((header) => header.includes(candidate.replace(/_/g, " ")) || header === candidate);
+    if (index >= 0) {
+      return index;
+    }
+  }
+  return normalized.findIndex((header) => header.includes("second"));
+};
+
+const findNameColumnIndex = (rowHeaders) => {
+  const normalized = rowHeaders.map((header) => String(header).toLowerCase());
+  const categoryIndex = normalized.findIndex((header) => header === "category");
+  if (categoryIndex >= 0) {
+    return categoryIndex;
+  }
+  const activityIndex = normalized.findIndex((header) => header.includes("activity"));
+  if (activityIndex >= 0) {
+    return activityIndex;
+  }
+  return normalized.length > 1 ? normalized.length - 1 : 1;
+};
+
+const fetchAnalyticData = async (apiKey, { kind, begin, end }) => {
+  const url = new URL("https://www.rescuetime.com/anapi/data");
+  url.searchParams.set("format", "json");
+  url.searchParams.set("perspective", "rank");
+  url.searchParams.set("restrict_kind", kind);
+  url.searchParams.set("restrict_begin", begin);
+  url.searchParams.set("restrict_end", end);
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`RescueTime API ${response.status}: ${body.slice(0, 200)}`);
+  }
+
+  return response.json();
+};
+
+const parseRankRows = (payload) => {
+  const headers = payload.row_headers ?? [];
+  const secondsIndex = findSecondsColumnIndex(headers);
+  const nameIndex = findNameColumnIndex(headers);
+
+  if (secondsIndex < 0) {
+    throw new Error(`Could not locate seconds column in headers: ${headers.join(", ")}`);
+  }
+
+  const rows = (payload.rows ?? []).map((row) => {
+    const name = String(row[nameIndex] ?? row[1] ?? "unknown");
+    const seconds = Number(row[secondsIndex] ?? 0);
+    return {
+      name,
+      seconds,
+      hours: seconds / 3600
+    };
+  });
+
+  return rows.sort((left, right) => right.seconds - left.seconds);
+};
+
+const parseObjectiveSpec = (spec) => {
+  const lastColon = spec.lastIndexOf(":");
+  if (lastColon <= 0) {
+    throw new Error(`Invalid --objective "${spec}". Expected "Category Name:targetHours".`);
+  }
+  const name = spec.slice(0, lastColon).trim();
+  const targetHours = Number(spec.slice(lastColon + 1));
+  if (!name || !Number.isFinite(targetHours) || targetHours <= 0) {
+    throw new Error(`Invalid --objective "${spec}".`);
+  }
+  return { name, targetHours };
+};
+
+const scoreObjective = (actualHours, targetHours) => Math.min(actualHours / targetHours, 1);
+
+const formatHours = (hours) => `${hours.toFixed(2)}h`;
+
+const main = async () => {
+  const apiKey = process.env.RESCUETIME_API_KEY?.trim();
+  if (!apiKey) {
+    console.error("Missing RESCUETIME_API_KEY in environment or .env");
+    process.exit(1);
+  }
+
+  const options = parseArgs();
+  const weekStart = options.week ? getWeekStartSunday(options.week) : getWeekStartSunday(new Date().toISOString().slice(0, 10));
+  const weekEnd = addDays(weekStart, 6);
+  const listKind = options.listKind ?? "category";
+
+  console.log(`Week: ${weekStart} → ${weekEnd}`);
+
+  const payload = await fetchAnalyticData(apiKey, {
+    kind: listKind,
+    begin: weekStart,
+    end: weekEnd
+  });
+
+  const rows = parseRankRows(payload);
+  const byName = new Map(rows.map((row) => [row.name, row]));
+
+  if (options.objectives.length === 0) {
+    console.log(`\nTop ${listKind} time (hours):`);
+    for (const row of rows.slice(0, 25)) {
+      console.log(`  ${row.name}: ${formatHours(row.hours)}`);
+    }
+    console.log("\nPass --objective \"Category:targetHours\" to score time objectives.");
+    return;
+  }
+
+  const results = options.objectives.map((spec) => {
+    const objective = parseObjectiveSpec(spec);
+    const row = byName.get(objective.name);
+    const actualHours = row?.hours ?? 0;
+    const achievement = scoreObjective(actualHours, objective.targetHours);
+    return {
+      ...objective,
+      actualHours,
+      achievement
+    };
+  });
+
+  const totalAchievement = results.reduce((sum, item) => sum + item.achievement, 0);
+  const scorePercent = (totalAchievement / results.length) * 100;
+
+  console.log("\nTime objective scores:");
+  for (const item of results) {
+    const found = byName.has(item.name) ? "" : " (not found in RescueTime data)";
+    console.log(
+      `  ${item.name}: ${formatHours(item.actualHours)} / ${formatHours(item.targetHours)} → ${item.achievement.toFixed(2)}/1${found}`
+    );
+  }
+
+  console.log(`\nWeekly time objectives score: ${totalAchievement.toFixed(2)} / ${results.length} = ${scorePercent.toFixed(1)}%`);
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,7 @@ tauri-build = { version = "2.5.6", features = [] }
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tauri = { version = "2.10.3", features = [] }
 tauri-plugin-notification = "2"
 tauri-plugin-sql = { version = "2.3.2", features = ["sqlite"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,11 +45,38 @@ fn resolve_storage_paths(app: tauri::AppHandle) -> Result<StoragePaths, String> 
     })
 }
 
+#[tauri::command]
+async fn rescuetime_http_get(url: String, api_key: String) -> Result<String, String> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .send()
+        .await
+        .map_err(|error| format!("RescueTime HTTP request failed: {error}"))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|error| format!("RescueTime HTTP response unreadable: {error}"))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "RescueTime API {}: {}",
+            status.as_u16(),
+            body.chars().take(200).collect::<String>()
+        ));
+    }
+
+    Ok(body)
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_sql::Builder::default().build())
-        .invoke_handler(tauri::generate_handler![resolve_storage_paths])
+        .invoke_handler(tauri::generate_handler![resolve_storage_paths, rescuetime_http_get])
         .run(tauri::generate_context!())
         .expect("error while running Trackdidia");
 }

--- a/src/domain/annual-goals.test.ts
+++ b/src/domain/annual-goals.test.ts
@@ -45,6 +45,10 @@ describe("annual goals domain", () => {
         tasksAddedTotal: 0,
         tasksCompletedTotal: 0,
         tasksCompletionRate: 0,
+        calorieAverage: 0,
+        physicalActivity: 0,
+        productivityPulse: null,
+        rescueTimeGoalsScore: null,
         weeklyScore: 0.5,
         days: []
       },
@@ -64,6 +68,10 @@ describe("annual goals domain", () => {
         tasksAddedTotal: 0,
         tasksCompletedTotal: 0,
         tasksCompletionRate: 0,
+        calorieAverage: 0,
+        physicalActivity: 0,
+        productivityPulse: null,
+        rescueTimeGoalsScore: null,
         weeklyScore: 0.55,
         days: []
       }

--- a/src/domain/annual-goals.ts
+++ b/src/domain/annual-goals.ts
@@ -74,7 +74,15 @@ const sourceDefinitions: AnnualGoalSourceDefinition[] = [
     label: "Score hebdo moyen",
     type: "weekly_summary",
     weeklyMetricLabels: ["Score hebdo"],
-    dailyHabitLabels: ["Sommeil", "TRC", "Temps d'ecran", "Pomodoris", "Discipline", "Taches"],
+    dailyHabitLabels: [
+      "Sommeil",
+      "TRC",
+      "Temps d'ecran",
+      "Temps focus",
+      "Discipline",
+      "Taches",
+      "Depense calorique"
+    ],
     computeCurrent: (_entries, weeklySummaries) => {
       const value = weeklyAverage(weeklySummaries, (summary) => summary.weeklyScore);
       return value === null ? null : value * 100;

--- a/src/domain/daily-entry.ts
+++ b/src/domain/daily-entry.ts
@@ -54,6 +54,7 @@ export const defaultAppSettings = (): AppSettings => ({
   aiApiKey: "",
   aiBaseUrl: "https://openrouter.ai/api/v1",
   aiModel: "moonshotai/kimi-k2.6",
+  rescuetimeApiKey: "",
   autoBackupEnabled: true,
   autoBackupIntervalHours: 24,
   lastBackupAt: "",

--- a/src/domain/monthly-review.test.ts
+++ b/src/domain/monthly-review.test.ts
@@ -62,6 +62,10 @@ describe("monthly review domain", () => {
         tasksAddedTotal: 16,
         tasksCompletedTotal: 12,
         tasksCompletionRate: 75,
+        calorieAverage: 0,
+        physicalActivity: 0,
+        productivityPulse: null,
+        rescueTimeGoalsScore: null,
         weeklyScore: 0.6,
         days: []
       }

--- a/src/domain/rescuetime-goals.test.ts
+++ b/src/domain/rescuetime-goals.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeRescueTimeGoalsSnapshot,
+  rescueTimeLabelsMatch,
+  scheduleDaysInWeek,
+  scoreLessGoal,
+  scoreMoreGoal
+} from "./rescuetime-goals";
+
+describe("rescuetime-goals", () => {
+  it("scores fractional more-time goals", () => {
+    expect(scoreMoreGoal(3600, 7200)).toBe(0.5);
+    expect(scoreMoreGoal(10800, 7200)).toBe(1);
+  });
+
+  it("scores less-time goals with partial credit when over target", () => {
+    expect(scoreLessGoal(1800, 3600)).toBe(1);
+    expect(scoreLessGoal(7200, 3600)).toBe(0.5);
+  });
+
+  it("computes weekly score as average achievement", () => {
+    const snapshot = computeRescueTimeGoalsSnapshot(
+      "2026-08-02",
+      "2026-08-08",
+      [
+        {
+          goalId: 1,
+          title: "A",
+          isMore: true,
+          actualHours: 1,
+          weeklyTargetHours: 2,
+          achievement: 0.5,
+          scheduleLabel: "24x7"
+        },
+        {
+          goalId: 2,
+          title: "B",
+          isMore: true,
+          actualHours: 2,
+          weeklyTargetHours: 2,
+          achievement: 1,
+          scheduleLabel: "24x7"
+        }
+      ],
+      { rescuetimeConfigured: true }
+    );
+
+    expect(snapshot.totalAchievement).toBe(1.5);
+    expect(snapshot.score).toBe(0.75);
+  });
+
+  it("maps working-day schedules to five days", () => {
+    expect(scheduleDaysInWeek("Working days")).toBe(5);
+    expect(scheduleDaysInWeek("24x7")).toBe(7);
+  });
+
+  it("matches project labels fuzzily", () => {
+    expect(rescueTimeLabelsMatch("Advanceo - CTO", "Advanceo Fractional CTO")).toBe(true);
+  });
+});

--- a/src/domain/rescuetime-goals.ts
+++ b/src/domain/rescuetime-goals.ts
@@ -1,0 +1,99 @@
+export interface RescueTimeGoalRecord {
+  id: number;
+  display_name: string;
+  taxon_display_name?: string;
+  amount_seconds: number;
+  is_more: boolean;
+  enabled?: boolean;
+  taxonomy_name?: string;
+  schedule_name?: string;
+  schedule?: { name?: string };
+  taxon_id: number;
+  taxonomy?: { search_name?: string };
+  productivity?: { id?: number; display_name?: string; name?: string };
+  overview?: { name?: string };
+  v2project?: { name?: string };
+}
+
+export interface RescueTimeGoalItemSnapshot {
+  goalId: number;
+  title: string;
+  isMore: boolean;
+  actualHours: number;
+  weeklyTargetHours: number;
+  achievement: number;
+  scheduleLabel: string;
+}
+
+export interface RescueTimeGoalsSnapshot {
+  weekStartDate: string;
+  weekEndDate: string;
+  items: RescueTimeGoalItemSnapshot[];
+  totalAchievement: number;
+  score: number | null;
+  rescuetimeConfigured: boolean;
+  fetchError?: string;
+}
+
+export const scheduleDaysInWeek = (scheduleName: string | undefined): number => {
+  const normalized = (scheduleName ?? "").toLowerCase();
+  if (normalized.includes("working") || normalized.includes("weekday")) {
+    return 5;
+  }
+  return 7;
+};
+
+export const scoreMoreGoal = (actualSeconds: number, targetSeconds: number): number => {
+  if (targetSeconds <= 0) {
+    return 0;
+  }
+  return Math.min(Math.max(0, actualSeconds) / targetSeconds, 1);
+};
+
+export const scoreLessGoal = (actualSeconds: number, targetSeconds: number): number => {
+  if (targetSeconds <= 0) {
+    return 0;
+  }
+  const actual = Math.max(0, actualSeconds);
+  if (actual <= targetSeconds) {
+    return 1;
+  }
+  return Math.min(targetSeconds / actual, 1);
+};
+
+export const computeRescueTimeGoalsSnapshot = (
+  weekStartDate: string,
+  weekEndDate: string,
+  items: RescueTimeGoalItemSnapshot[],
+  options: { rescuetimeConfigured: boolean; fetchError?: string }
+): RescueTimeGoalsSnapshot => {
+  const achievements = items.map((item) => item.achievement);
+  const totalAchievement = achievements.reduce((sum, achievement) => sum + achievement, 0);
+
+  return {
+    weekStartDate,
+    weekEndDate,
+    items,
+    totalAchievement,
+    score: achievements.length > 0 ? totalAchievement / achievements.length : null,
+    rescuetimeConfigured: options.rescuetimeConfigured,
+    fetchError: options.fetchError
+  };
+};
+
+export const normalizeRescueTimeLabel = (value: string): string =>
+  value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+export const rescueTimeLabelsMatch = (left: string, right: string): boolean => {
+  const a = normalizeRescueTimeLabel(left);
+  const b = normalizeRescueTimeLabel(right);
+  if (!a || !b) {
+    return false;
+  }
+  return a.includes(b) || b.includes(a) || a.split(" ").some((token) => token.length > 3 && b.includes(token));
+};

--- a/src/domain/rescuetime-goals.ts
+++ b/src/domain/rescuetime-goals.ts
@@ -7,10 +7,16 @@ export interface RescueTimeGoalRecord {
   enabled?: boolean;
   taxonomy_name?: string;
   schedule_name?: string;
-  schedule?: { name?: string };
+  schedule_id?: number;
+  schedule?: { id?: number; name?: string };
   taxon_id: number;
   taxonomy?: { search_name?: string };
-  productivity?: { id?: number; display_name?: string; name?: string };
+  productivity?: {
+    id?: number;
+    display_name?: string;
+    name?: string;
+    sql_score_equals?: string;
+  };
   overview?: { name?: string };
   v2project?: { name?: string };
 }
@@ -37,7 +43,11 @@ export interface RescueTimeGoalsSnapshot {
 
 export const scheduleDaysInWeek = (scheduleName: string | undefined): number => {
   const normalized = (scheduleName ?? "").toLowerCase();
-  if (normalized.includes("working") || normalized.includes("weekday")) {
+  if (
+    normalized.includes("working") ||
+    normalized.includes("weekday") ||
+    normalized.includes("work hour")
+  ) {
     return 5;
   }
   return 7;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -76,6 +76,7 @@ export interface WeeklyReviewDaySummary {
   trcRespected: boolean;
   screenTimeMinutes: number;
   pomodoris: number;
+  calorieExpenditure: number;
   disciplineScore: number;
   tasksAdded: number;
   tasksCompleted: number;
@@ -97,6 +98,10 @@ export interface WeeklyReviewSummary {
   tasksAddedTotal: number;
   tasksCompletedTotal: number;
   tasksCompletionRate: number;
+  calorieAverage: number;
+  physicalActivity: number;
+  productivityPulse: number | null;
+  rescueTimeGoalsScore: number | null;
   weeklyScore: number;
   days: WeeklyReviewDaySummary[];
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -214,6 +214,55 @@ export interface AnnualGoalSnapshot {
   linkedDailyHabitLabels: string[];
 }
 
+export type WeeklyObjectiveKind = "time" | "manual";
+
+export type RescueTimeTaxonomy = "overview" | "category" | "activity" | "productivity";
+
+export interface WeeklyObjective {
+  id: string;
+  title: string;
+  kind: WeeklyObjectiveKind;
+  targetHours: number | null;
+  rescuetimeKind: RescueTimeTaxonomy | null;
+  rescuetimeThing: string | null;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WeeklyObjectiveResult {
+  weekStartDate: string;
+  objectiveId: string;
+  achieved: boolean;
+  updatedAt: string;
+}
+
+export type WeeklyObjectiveItemSource = "rescuetime" | "manual" | "missing";
+
+export interface WeeklyObjectiveItemSnapshot {
+  objective: WeeklyObjective;
+  actualHours: number | null;
+  achievement: number;
+  source: WeeklyObjectiveItemSource;
+  error?: string;
+}
+
+export interface WeeklyObjectivesSnapshot {
+  weekStartDate: string;
+  weekEndDate: string;
+  items: WeeklyObjectiveItemSnapshot[];
+  totalAchievement: number;
+  score: number | null;
+  rescuetimeConfigured: boolean;
+  fetchError?: string;
+}
+
+export interface RescueTimeTaxonomyEntry {
+  name: string;
+  seconds: number;
+  hours: number;
+}
+
 export interface AppSettings {
   language: "fr";
   storageMode: "sqlite";
@@ -221,6 +270,7 @@ export interface AppSettings {
   aiApiKey: string;
   aiBaseUrl: string;
   aiModel: string;
+  rescuetimeApiKey: string;
   autoBackupEnabled: boolean;
   autoBackupIntervalHours: number;
   lastBackupAt: string;

--- a/src/domain/weekly-objectives.test.ts
+++ b/src/domain/weekly-objectives.test.ts
@@ -1,0 +1,76 @@
+import {
+  buildWeeklyObjectivesSnapshot,
+  computeWeeklyObjectivesScore,
+  createEmptyWeeklyObjective,
+  scoreManualObjective,
+  scoreTimeObjective
+} from "./weekly-objectives";
+import type { WeeklyObjectiveResult } from "./types";
+
+describe("weekly-objectives scoring", () => {
+  it("scores fractional time objectives and caps at 1", () => {
+    expect(scoreTimeObjective(1, 2)).toBe(0.5);
+    expect(scoreTimeObjective(3, 2)).toBe(1);
+    expect(scoreTimeObjective(null, 2)).toBe(0);
+    expect(scoreTimeObjective(1, 0)).toBe(0);
+  });
+
+  it("scores manual objectives as binary", () => {
+    expect(scoreManualObjective(true)).toBe(1);
+    expect(scoreManualObjective(false)).toBe(0);
+  });
+
+  it("computes aggregate score as average achievement", () => {
+    expect(computeWeeklyObjectivesScore([1, 1, 0.5, 1, 1, 1, 1, 1, 1, 1])).toBe(0.95);
+    expect(computeWeeklyObjectivesScore([])).toBeNull();
+  });
+
+  it("builds a mixed snapshot with manual and time objectives", () => {
+    const timeObjective = createEmptyWeeklyObjective({
+      id: "time-1",
+      title: "Software Development",
+      kind: "time",
+      targetHours: 2,
+      rescuetimeKind: "category",
+      rescuetimeThing: "Software Development"
+    });
+    const manualObjective = createEmptyWeeklyObjective({
+      id: "manual-1",
+      title: "Budget review",
+      kind: "manual"
+    });
+    const results: WeeklyObjectiveResult[] = [
+      {
+        weekStartDate: "2026-08-02",
+        objectiveId: "manual-1",
+        achieved: true,
+        updatedAt: "2026-08-09T12:00:00.000Z"
+      }
+    ];
+
+    const snapshot = buildWeeklyObjectivesSnapshot(
+      "2026-08-02",
+      [timeObjective, manualObjective],
+      results,
+      { "time-1": 3600 },
+      { rescuetimeConfigured: true }
+    );
+
+    expect(snapshot.weekStartDate).toBe("2026-08-02");
+    expect(snapshot.weekEndDate).toBe("2026-08-08");
+    expect(snapshot.items).toHaveLength(2);
+    expect(snapshot.items.find((item) => item.objective.id === "time-1")).toMatchObject({
+      objective: timeObjective,
+      actualHours: 1,
+      achievement: 0.5,
+      source: "rescuetime"
+    });
+    expect(snapshot.items.find((item) => item.objective.id === "manual-1")).toMatchObject({
+      objective: manualObjective,
+      achievement: 1,
+      source: "manual"
+    });
+    expect(snapshot.totalAchievement).toBe(1.5);
+    expect(snapshot.score).toBe(0.75);
+  });
+});

--- a/src/domain/weekly-objectives.ts
+++ b/src/domain/weekly-objectives.ts
@@ -1,0 +1,128 @@
+import { addDays } from "../lib/gtd/shared";
+import { buildWeekDates } from "./weekly-review";
+import type {
+  WeeklyObjective,
+  WeeklyObjectiveItemSnapshot,
+  WeeklyObjectiveResult,
+  WeeklyObjectivesSnapshot
+} from "./types";
+
+export interface RescueTimeSecondsByObjectiveId {
+  [objectiveId: string]: number | null;
+}
+
+export interface RescueTimeErrorsByObjectiveId {
+  [objectiveId: string]: string | undefined;
+}
+
+export const scoreTimeObjective = (actualHours: number | null, targetHours: number | null): number => {
+  if (actualHours === null || targetHours === null || !Number.isFinite(targetHours) || targetHours <= 0) {
+    return 0;
+  }
+
+  const safeActual = Math.max(0, actualHours);
+  return Math.min(safeActual / targetHours, 1);
+};
+
+export const scoreManualObjective = (achieved: boolean): number => (achieved ? 1 : 0);
+
+export const computeWeeklyObjectivesScore = (achievements: number[]): number | null => {
+  if (achievements.length === 0) {
+    return null;
+  }
+
+  const total = achievements.reduce((sum, achievement) => sum + achievement, 0);
+  return total / achievements.length;
+};
+
+export const cloneWeeklyObjective = (objective: WeeklyObjective): WeeklyObjective => ({
+  ...objective
+});
+
+export const createEmptyWeeklyObjective = (
+  partial: Partial<WeeklyObjective> = {},
+  timestamp = new Date().toISOString()
+): WeeklyObjective => ({
+  id: partial.id ?? "",
+  title: partial.title ?? "",
+  kind: partial.kind ?? "manual",
+  targetHours: partial.targetHours ?? null,
+  rescuetimeKind: partial.rescuetimeKind ?? null,
+  rescuetimeThing: partial.rescuetimeThing ?? null,
+  sortOrder: partial.sortOrder ?? 0,
+  createdAt: partial.createdAt ?? timestamp,
+  updatedAt: partial.updatedAt ?? timestamp
+});
+
+export const buildWeeklyObjectivesSnapshot = (
+  weekStartDate: string,
+  objectives: WeeklyObjective[],
+  results: WeeklyObjectiveResult[],
+  rescuetimeSecondsByObjectiveId: RescueTimeSecondsByObjectiveId,
+  options: {
+    rescuetimeConfigured: boolean;
+    fetchError?: string;
+    errorsByObjectiveId?: RescueTimeErrorsByObjectiveId;
+  }
+): WeeklyObjectivesSnapshot => {
+  const normalized = buildWeekDates(weekStartDate);
+  const weekEndDate = addDays(normalized, 6);
+  const resultsByObjectiveId = new Map(results.map((result) => [result.objectiveId, result]));
+  const sortedObjectives = [...objectives].sort(
+    (left, right) => left.sortOrder - right.sortOrder || left.title.localeCompare(right.title)
+  );
+
+  const items: WeeklyObjectiveItemSnapshot[] = sortedObjectives.map((objective) => {
+    if (objective.kind === "manual") {
+      const result = resultsByObjectiveId.get(objective.id);
+      return {
+        objective,
+        actualHours: null,
+        achievement: scoreManualObjective(result?.achieved ?? false),
+        source: "manual"
+      };
+    }
+
+    const error = options.errorsByObjectiveId?.[objective.id];
+    if (error) {
+      return {
+        objective,
+        actualHours: null,
+        achievement: 0,
+        source: "missing",
+        error
+      };
+    }
+
+    const seconds = rescuetimeSecondsByObjectiveId[objective.id];
+    if (seconds === undefined || seconds === null) {
+      return {
+        objective,
+        actualHours: null,
+        achievement: 0,
+        source: "missing"
+      };
+    }
+
+    const actualHours = seconds / 3600;
+    return {
+      objective,
+      actualHours,
+      achievement: scoreTimeObjective(actualHours, objective.targetHours),
+      source: "rescuetime"
+    };
+  });
+
+  const achievements = items.map((item) => item.achievement);
+  const totalAchievement = achievements.reduce((sum, achievement) => sum + achievement, 0);
+
+  return {
+    weekStartDate: normalized,
+    weekEndDate,
+    items,
+    totalAchievement,
+    score: computeWeeklyObjectivesScore(achievements),
+    rescuetimeConfigured: options.rescuetimeConfigured,
+    fetchError: options.fetchError
+  };
+};

--- a/src/domain/weekly-review.test.ts
+++ b/src/domain/weekly-review.test.ts
@@ -5,7 +5,14 @@ import {
   updateMetric,
   updatePrinciple
 } from "./daily-entry";
-import { buildWeeklyReviewSummary, createEmptyWeeklyReview, updateWeeklyReviewChecklist, updateWeeklyReviewNote } from "./weekly-review";
+import {
+  applyWeeklyScoreExternalAxes,
+  buildWeeklyReviewSummary,
+  createEmptyWeeklyReview,
+  localWeeklyScoreAxes,
+  updateWeeklyReviewChecklist,
+  updateWeeklyReviewNote
+} from "./weekly-review";
 
 describe("weekly review domain", () => {
   it("builds weekly aggregates from seven daily entries", () => {
@@ -56,6 +63,10 @@ describe("weekly review domain", () => {
     expect(summary.tasksCompletedTotal).toBe(21);
     expect(summary.tasksCompletionRate).toBeCloseTo(75);
     expect(summary.disciplineAverage).toBeGreaterThan(0);
+    expect(summary.calorieAverage).toBe(0);
+    expect(summary.physicalActivity).toBe(0);
+    expect(summary.productivityPulse).toBeNull();
+    expect(summary.rescueTimeGoalsScore).toBeNull();
     expect(summary.weeklyScore).toBeGreaterThan(0);
     expect(summary.days).toHaveLength(7);
   });
@@ -120,5 +131,80 @@ describe("weekly review domain", () => {
     expect(review.notes.bilan).toBe("");
     expect(withNote.notes.bilan).toBe("Semaine dense.");
     expect(withCheck.ritualChecklist.dimanche).toBe(true);
+  });
+
+  it("includes calorie expenditure in weekly and daily summaries", () => {
+    const weekDates = [
+      "2026-03-29",
+      "2026-03-30",
+      "2026-03-31",
+      "2026-04-01",
+      "2026-04-02",
+      "2026-04-03",
+      "2026-04-04"
+    ];
+
+    const entries = weekDates.map((date, index) => {
+      let entry = createEmptyDailyEntry(date);
+      entry = updateMetric(entry, "depenseCalorique", 3800 + index * 100);
+      return entry;
+    });
+
+    const summary = buildWeeklyReviewSummary("2026-03-29", entries);
+
+    expect(summary.calorieAverage).toBeCloseTo(4100);
+    expect(summary.physicalActivity).toBeCloseTo((4100 * 100) / 3800);
+    expect(summary.days.every((day) => day.calorieExpenditure > 0)).toBe(true);
+  });
+
+  it("recomputes weekly score with RescueTime axes when provided", () => {
+    const summary = buildWeeklyReviewSummary("2026-03-29", [
+      createEmptyDailyEntry("2026-03-29"),
+      createEmptyDailyEntry("2026-03-30"),
+      createEmptyDailyEntry("2026-03-31"),
+      createEmptyDailyEntry("2026-04-01"),
+      createEmptyDailyEntry("2026-04-02"),
+      createEmptyDailyEntry("2026-04-03"),
+      createEmptyDailyEntry("2026-04-04")
+    ]);
+
+    const localScore = summary.weeklyScore;
+    const withRescueTime = applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore: 0.5,
+      productivityPulse: 80
+    });
+
+    expect(withRescueTime.rescueTimeGoalsScore).toBe(0.5);
+    expect(withRescueTime.productivityPulse).toBe(80);
+    expect(withRescueTime.weeklyScore).toBeGreaterThan(localScore);
+    expect(localWeeklyScoreAxes(withRescueTime)).toHaveLength(7);
+  });
+
+  it("ignores RescueTime fields already on summary when computing local axes", () => {
+    const summary = applyWeeklyScoreExternalAxes(
+      buildWeeklyReviewSummary("2026-03-29", [
+        createEmptyDailyEntry("2026-03-29"),
+        createEmptyDailyEntry("2026-03-30"),
+        createEmptyDailyEntry("2026-03-31"),
+        createEmptyDailyEntry("2026-04-01"),
+        createEmptyDailyEntry("2026-04-02"),
+        createEmptyDailyEntry("2026-04-03"),
+        createEmptyDailyEntry("2026-04-04")
+      ]),
+      {
+        rescueTimeGoalsScore: 1,
+        productivityPulse: 100
+      }
+    );
+
+    const reapplied = applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore: null,
+      productivityPulse: null
+    });
+
+    expect(reapplied.rescueTimeGoalsScore).toBeNull();
+    expect(reapplied.productivityPulse).toBeNull();
+    expect(reapplied.weeklyScore).toBeLessThan(summary.weeklyScore);
+    expect(localWeeklyScoreAxes(summary)).toEqual(localWeeklyScoreAxes(reapplied));
   });
 });

--- a/src/domain/weekly-review.ts
+++ b/src/domain/weekly-review.ts
@@ -13,6 +13,7 @@ import type {
 
 const phoneScreenTargetMinutes = 840;
 const pomodoroTarget = 56;
+const calorieTargetDaily = 3800;
 
 const emptyWeeklyNotes = (): WeeklyReviewNotes => ({
   bilan: "",
@@ -59,6 +60,9 @@ const toPhoneScreenAxisValue = (totalMinutes: number): number =>
 
 const toPomodoroAxisValue = (pomodorisTotal: number): number =>
   pomodoroTarget > 0 ? clampAtZero((pomodorisTotal * 100) / pomodoroTarget) : 0;
+
+const toPhysicalActivityAxisValue = (calorieAverage: number): number =>
+  calorieTargetDaily > 0 ? clampAtZero((calorieAverage * 100) / calorieTargetDaily) : 0;
 
 export const buildWeekDates = (weekStartDate: string): string => {
   const normalized = getWeekStartSunday(weekStartDate);
@@ -131,10 +135,46 @@ const buildDaySummary = (entry: DailyEntry): WeeklyReviewDaySummary => ({
   trcRespected: entry.principleChecks.respectTrc === true,
   screenTimeMinutes: resolveMetricValue(entry, "tempsEcranTelephone") ?? 0,
   pomodoris: resolveMetricValue(entry, "pomodoris") ?? 0,
+  calorieExpenditure: resolveMetricValue(entry, "depenseCalorique") ?? 0,
   disciplineScore: computeDisciplineScore(entry),
   tasksAdded: resolveMetricValue(entry, "tachesAjoutes") ?? 0,
   tasksCompleted: resolveMetricValue(entry, "tachesRealises") ?? 0
 });
+
+export const localWeeklyScoreAxes = (summary: WeeklyReviewSummary): number[] => [
+  scoreAgainstTarget(summary.sleepQuality, 100),
+  scoreAgainstTarget(summary.respectTrc, 100),
+  scoreAgainstTarget(summary.phoneScreenTime, 100),
+  scoreAgainstTarget(summary.pomodoris, 100),
+  scoreAgainstTarget(summary.discipline, 100),
+  scoreAgainstTarget(summary.tasksCompletionRate, 100),
+  scoreAgainstTarget(summary.physicalActivity, 100)
+];
+
+export const applyWeeklyScoreExternalAxes = (
+  summary: WeeklyReviewSummary,
+  external: {
+    rescueTimeGoalsScore: number | null;
+    productivityPulse: number | null;
+  }
+): WeeklyReviewSummary => {
+  const axisScores = [...localWeeklyScoreAxes(summary)];
+
+  if (external.rescueTimeGoalsScore !== null) {
+    axisScores.push(scoreAgainstTarget(external.rescueTimeGoalsScore * 100, 100));
+  }
+
+  if (external.productivityPulse !== null) {
+    axisScores.push(scoreAgainstTarget(external.productivityPulse, 100));
+  }
+
+  return {
+    ...summary,
+    rescueTimeGoalsScore: external.rescueTimeGoalsScore,
+    productivityPulse: external.productivityPulse,
+    weeklyScore: average(axisScores)
+  };
+};
 
 export const buildWeeklyReviewSummary = (
   weekStartDate: string,
@@ -150,6 +190,7 @@ export const buildWeeklyReviewSummary = (
   const trcDaysRespected = daySummaries.filter((day) => day.trcRespected).length;
   const screenTimeTotalMinutes = daySummaries.reduce((sum, day) => sum + day.screenTimeMinutes, 0);
   const pomodorisTotal = daySummaries.reduce((sum, day) => sum + day.pomodoris, 0);
+  const calorieAverage = average(daySummaries.map((day) => day.calorieExpenditure));
   const disciplineAverage = average(daySummaries.map((day) => day.disciplineScore));
   const tasksAddedTotal = daySummaries.reduce((sum, day) => sum + day.tasksAdded, 0);
   const tasksCompletedTotal = daySummaries.reduce((sum, day) => sum + day.tasksCompleted, 0);
@@ -157,19 +198,12 @@ export const buildWeeklyReviewSummary = (
   const respectTrc = (trcDaysRespected / 7) * 100;
   const phoneScreenTime = toPhoneScreenAxisValue(screenTimeTotalMinutes);
   const pomodoris = toPomodoroAxisValue(pomodorisTotal);
+  const physicalActivity = toPhysicalActivityAxisValue(calorieAverage);
   const discipline = disciplineAverage * 100;
   const tasksCompletionRate =
     tasksAddedTotal > 0 ? (tasksCompletedTotal / tasksAddedTotal) * 100 : 0;
-  const weeklyScore = average([
-    scoreAgainstTarget(sleepQuality, 100),
-    scoreAgainstTarget(respectTrc, 100),
-    scoreAgainstTarget(phoneScreenTime, 100),
-    scoreAgainstTarget(pomodoris, 100),
-    scoreAgainstTarget(discipline, 100),
-    scoreAgainstTarget(tasksCompletionRate, 100)
-  ]);
 
-  return {
+  const baseSummary: WeeklyReviewSummary = {
     weekStartDate: normalized,
     weekEndDate: addDays(normalized, 6),
     sleepAverage,
@@ -185,7 +219,16 @@ export const buildWeeklyReviewSummary = (
     tasksAddedTotal,
     tasksCompletedTotal,
     tasksCompletionRate,
-    weeklyScore,
+    calorieAverage,
+    physicalActivity,
+    productivityPulse: null,
+    rescueTimeGoalsScore: null,
+    weeklyScore: 0,
     days: daySummaries
+  };
+
+  return {
+    ...baseSummary,
+    weeklyScore: average(localWeeklyScoreAxes(baseSummary))
   };
 };

--- a/src/lib/rescuetime/client.test.ts
+++ b/src/lib/rescuetime/client.test.ts
@@ -1,0 +1,52 @@
+import { HttpRescueTimeClient } from "./client";
+
+describe("HttpRescueTimeClient", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("calls the Analytic Data API with bearer auth and week bounds", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        row_headers: ["Rank", "Time Spent (seconds)", "Category"],
+        rows: [[1, 3600, "Software Development"]]
+      })
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = new HttpRescueTimeClient();
+    const payload = await client.fetchAnalyticData("rt-test-key", {
+      kind: "category",
+      begin: "2026-08-03",
+      end: "2026-08-09"
+    });
+
+    expect(payload.rows).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [URL | string, RequestInit];
+    const urlText = String(url);
+    expect(urlText).toContain("https://www.rescuetime.com/anapi/data");
+    expect(urlText).toContain("restrict_kind=category");
+    expect(urlText).toContain("restrict_begin=2026-08-03");
+    expect(urlText).toContain("restrict_end=2026-08-09");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer rt-test-key");
+  });
+
+  it("surfaces RescueTime error responses", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response("Unauthorized", { status: 401 })
+    ) as typeof fetch;
+
+    const client = new HttpRescueTimeClient();
+
+    await expect(
+      client.fetchAnalyticData("bad-key", {
+        kind: "category",
+        begin: "2026-08-03",
+        end: "2026-08-09"
+      })
+    ).rejects.toThrow("RescueTime API 401");
+  });
+});

--- a/src/lib/rescuetime/client.ts
+++ b/src/lib/rescuetime/client.ts
@@ -1,0 +1,38 @@
+import type { RescueTimeTaxonomy } from "../../domain/types";
+import type { RescueTimeAnalyticPayload } from "./parse-analytic-data";
+
+export interface RescueTimeFetchOptions {
+  kind: RescueTimeTaxonomy;
+  begin: string;
+  end: string;
+}
+
+export interface RescueTimeClient {
+  fetchAnalyticData(apiKey: string, options: RescueTimeFetchOptions): Promise<RescueTimeAnalyticPayload>;
+}
+
+export class HttpRescueTimeClient implements RescueTimeClient {
+  async fetchAnalyticData(apiKey: string, options: RescueTimeFetchOptions): Promise<RescueTimeAnalyticPayload> {
+    const url = new URL("https://www.rescuetime.com/anapi/data");
+    url.searchParams.set("format", "json");
+    url.searchParams.set("perspective", "rank");
+    url.searchParams.set("restrict_kind", options.kind);
+    url.searchParams.set("restrict_begin", options.begin);
+    url.searchParams.set("restrict_end", options.end);
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`
+      }
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`RescueTime API ${response.status}: ${body.slice(0, 200)}`);
+    }
+
+    return response.json() as Promise<RescueTimeAnalyticPayload>;
+  }
+}
+
+export const defaultRescueTimeClient = new HttpRescueTimeClient();

--- a/src/lib/rescuetime/client.ts
+++ b/src/lib/rescuetime/client.ts
@@ -1,10 +1,12 @@
 import type { RescueTimeTaxonomy } from "../../domain/types";
 import type { RescueTimeAnalyticPayload } from "./parse-analytic-data";
+import { fetchRescueTimeJson } from "./http-transport";
 
 export interface RescueTimeFetchOptions {
   kind: RescueTimeTaxonomy;
   begin: string;
   end: string;
+  scheduleId?: number;
 }
 
 export interface RescueTimeClient {
@@ -19,19 +21,11 @@ export class HttpRescueTimeClient implements RescueTimeClient {
     url.searchParams.set("restrict_kind", options.kind);
     url.searchParams.set("restrict_begin", options.begin);
     url.searchParams.set("restrict_end", options.end);
-
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`
-      }
-    });
-
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`RescueTime API ${response.status}: ${body.slice(0, 200)}`);
+    if (options.scheduleId !== undefined && options.scheduleId > 0) {
+      url.searchParams.set("restrict_schedule_id", String(options.scheduleId));
     }
 
-    return response.json() as Promise<RescueTimeAnalyticPayload>;
+    return fetchRescueTimeJson<RescueTimeAnalyticPayload>(url.toString(), apiKey);
   }
 }
 

--- a/src/lib/rescuetime/goals-client.test.ts
+++ b/src/lib/rescuetime/goals-client.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import type { RescueTimeGoalRecord } from "../../domain/rescuetime-goals";
+import { matchRankRowSeconds } from "./goals-client";
+
+const overviewGoal = (name: string): RescueTimeGoalRecord => ({
+  id: 1,
+  display_name: `goal on ${name}`,
+  amount_seconds: 3600,
+  is_more: true,
+  taxon_id: 1,
+  taxonomy_name: "overview",
+  overview: { name }
+});
+
+describe("matchRankRowSeconds", () => {
+  const nestedRows = [
+    { name: "Work", seconds: 100, hours: 100 / 3600 },
+    { name: "Network Work", seconds: 200, hours: 200 / 3600 }
+  ];
+
+  it("prefers exact match over nested substring collision", () => {
+    expect(matchRankRowSeconds(nestedRows, overviewGoal("Network Work"), "overview")).toBe(200);
+  });
+
+  it("matches shorter label exactly without picking nested row", () => {
+    expect(matchRankRowSeconds(nestedRows, overviewGoal("Work"), "overview")).toBe(100);
+  });
+
+  it("returns nested row even when Work appears first in rank data", () => {
+    const reversedRows = [
+      { name: "Work", seconds: 100, hours: 100 / 3600 },
+      { name: "Network Work", seconds: 200, hours: 200 / 3600 }
+    ];
+    expect(matchRankRowSeconds(reversedRows, overviewGoal("Network Work"), "overview")).toBe(200);
+  });
+
+  it("prefers longest partial match when no exact match exists", () => {
+    const partialRows = [
+      { name: "Dev", seconds: 50, hours: 50 / 3600 },
+      { name: "Dev Tools", seconds: 150, hours: 150 / 3600 }
+    ];
+    expect(matchRankRowSeconds(partialRows, overviewGoal("Dev Tool"), "overview")).toBe(150);
+  });
+});

--- a/src/lib/rescuetime/goals-client.ts
+++ b/src/lib/rescuetime/goals-client.ts
@@ -1,4 +1,4 @@
-import type { RescueTimeGoalRecord } from "../../domain/rescuetime-goals";
+import { normalizeRescueTimeLabel, type RescueTimeGoalRecord } from "../../domain/rescuetime-goals";
 import { addDays } from "../gtd/shared";
 import type { RescueTimeAnalyticPayload } from "./parse-analytic-data";
 import { parseRankRows } from "./parse-analytic-data";
@@ -138,25 +138,45 @@ export const matchRankRowSeconds = (
   goal: RescueTimeGoalRecord,
   kind: string
 ): number => {
-  const needle = (
+  const needle = normalizeRescueTimeLabel(
     goal.taxon_display_name ??
-    goal.overview?.name ??
-    goal.v2project?.name ??
-    goal.productivity?.display_name ??
-    goal.productivity?.name ??
-    ""
-  ).toLowerCase();
+      goal.overview?.name ??
+      goal.v2project?.name ??
+      goal.productivity?.display_name ??
+      goal.productivity?.name ??
+      ""
+  );
 
   if (!needle) {
     return 0;
   }
 
-  const row = rows.find((item) => {
-    const name = item.name.toLowerCase();
-    return name === needle || name.includes(needle) || needle.includes(name);
-  });
+  for (const item of rows) {
+    const normalizedName = normalizeRescueTimeLabel(item.name);
+    if (normalizedName === needle) {
+      return item.seconds;
+    }
+  }
 
-  return row?.seconds ?? 0;
+  let bestMatch: { seconds: number; nameLength: number } | null = null;
+
+  for (const item of rows) {
+    const normalizedName = normalizeRescueTimeLabel(item.name);
+    if (!normalizedName) {
+      continue;
+    }
+
+    const isPartialMatch = normalizedName.includes(needle) || needle.includes(normalizedName);
+    if (!isPartialMatch) {
+      continue;
+    }
+
+    if (!bestMatch || normalizedName.length > bestMatch.nameLength) {
+      bestMatch = { seconds: item.seconds, nameLength: normalizedName.length };
+    }
+  }
+
+  return bestMatch?.seconds ?? 0;
 };
 
 export const goalScheduleId = (goal: RescueTimeGoalRecord): number =>

--- a/src/lib/rescuetime/goals-client.ts
+++ b/src/lib/rescuetime/goals-client.ts
@@ -1,8 +1,15 @@
 import type { RescueTimeGoalRecord } from "../../domain/rescuetime-goals";
+import { addDays } from "../gtd/shared";
 import type { RescueTimeAnalyticPayload } from "./parse-analytic-data";
 import { parseRankRows } from "./parse-analytic-data";
+import { fetchRescueTimeJson } from "./http-transport";
+import { productivitySecondsForGoal, type ParsedProductivityRow } from "./productivity-mapping";
+
+export { parseRankRows };
 
 export interface RescueTimeProjectTimesPayload {
+  is_complete?: boolean;
+  job_id?: string | number | null;
   project_times?: Array<{
     duration?: number;
     project?: {
@@ -13,65 +20,73 @@ export interface RescueTimeProjectTimesPayload {
   }>;
 }
 
+export interface RescueTimeAnalyticQuery {
+  kind: string;
+  begin: string;
+  end: string;
+  scheduleId?: number;
+}
+
 export interface RescueTimeGoalsClient {
   listGoals(apiKey: string): Promise<RescueTimeGoalRecord[]>;
-  fetchAnalyticData(apiKey: string, kind: string, begin: string, end: string): Promise<RescueTimeAnalyticPayload>;
+  fetchAnalyticData(apiKey: string, query: RescueTimeAnalyticQuery): Promise<RescueTimeAnalyticPayload>;
   fetchProjectTimes(apiKey: string, begin: string, end: string): Promise<RescueTimeProjectTimesPayload>;
 }
 
+const sleep = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
 export class HttpRescueTimeGoalsClient implements RescueTimeGoalsClient {
-  private async fetchJson<T>(apiKey: string, url: string): Promise<T> {
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${apiKey}`
-      }
-    });
-
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`RescueTime API ${response.status}: ${body.slice(0, 200)}`);
-    }
-
-    return response.json() as Promise<T>;
-  }
-
   async listGoals(apiKey: string): Promise<RescueTimeGoalRecord[]> {
-    const goals = await this.fetchJson<RescueTimeGoalRecord[]>(
-      apiKey,
-      "https://www.rescuetime.com/api/resource/goals"
+    const goals = await fetchRescueTimeJson<RescueTimeGoalRecord[]>(
+      "https://www.rescuetime.com/api/resource/goals",
+      apiKey
     );
     return goals.filter((goal) => goal.enabled !== false);
   }
 
-  async fetchAnalyticData(
-    apiKey: string,
-    kind: string,
-    begin: string,
-    end: string
-  ): Promise<RescueTimeAnalyticPayload> {
+  async fetchAnalyticData(apiKey: string, query: RescueTimeAnalyticQuery): Promise<RescueTimeAnalyticPayload> {
     const url = new URL("https://www.rescuetime.com/anapi/data");
     url.searchParams.set("format", "json");
     url.searchParams.set("perspective", "rank");
-    url.searchParams.set("restrict_kind", kind);
-    url.searchParams.set("restrict_begin", begin);
-    url.searchParams.set("restrict_end", end);
-    return this.fetchJson(apiKey, url.toString());
+    url.searchParams.set("restrict_kind", query.kind);
+    url.searchParams.set("restrict_begin", query.begin);
+    url.searchParams.set("restrict_end", query.end);
+    if (query.scheduleId !== undefined && query.scheduleId > 0) {
+      url.searchParams.set("restrict_schedule_id", String(query.scheduleId));
+    }
+    return fetchRescueTimeJson<RescueTimeAnalyticPayload>(url.toString(), apiKey);
   }
 
   async fetchProjectTimes(apiKey: string, begin: string, end: string): Promise<RescueTimeProjectTimesPayload> {
-    const url = new URL("https://www.rescuetime.com/api/resource/labeled_time_project_times");
-    url.searchParams.set("start_date", begin);
-    url.searchParams.set("end_date", end);
-    return this.fetchJson(apiKey, url.toString());
+    const projectTimes: NonNullable<RescueTimeProjectTimesPayload["project_times"]> = [];
+
+    for (let cursor = begin; cursor <= end; cursor = addDays(cursor, 1)) {
+      const url = new URL("https://www.rescuetime.com/api/resource/labeled_time_project_times");
+      url.searchParams.set("date", cursor);
+
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        const payload = await fetchRescueTimeJson<RescueTimeProjectTimesPayload>(url.toString(), apiKey);
+        if (payload.is_complete !== false) {
+          projectTimes.push(...(payload.project_times ?? []));
+          break;
+        }
+        if (attempt === 11) {
+          throw new Error(`RescueTime project times query did not complete for ${cursor}.`);
+        }
+        await sleep(500);
+      }
+    }
+
+    return { is_complete: true, project_times: projectTimes };
   }
 }
 
 export const defaultRescueTimeGoalsClient = new HttpRescueTimeGoalsClient();
 
-export interface ParsedProductivityRow {
-  productivity: number;
-  seconds: number;
-}
+export { productivitySecondsForGoal, type ParsedProductivityRow };
 
 export const parseProductivityRows = (payload: RescueTimeAnalyticPayload): ParsedProductivityRow[] => {
   const headers = payload.row_headers ?? [];
@@ -82,17 +97,6 @@ export const parseProductivityRows = (payload: RescueTimeAnalyticPayload): Parse
     productivity: Number(row[productivityIndex] ?? 0),
     seconds: Number(row[secondsIndex] ?? 0)
   }));
-};
-
-export const productivitySecondsForGoal = (rows: ParsedProductivityRow[], goal: RescueTimeGoalRecord): number => {
-  const productivityId = goal.productivity?.id ?? goal.taxon_id;
-  if (productivityId === 7) {
-    return rows.filter((row) => row.productivity < 0).reduce((sum, row) => sum + row.seconds, 0);
-  }
-  if (productivityId === 10) {
-    return rows.reduce((sum, row) => sum + row.seconds, 0);
-  }
-  return 0;
 };
 
 export const aggregateProjectTimes = (payload: RescueTimeProjectTimesPayload) => {
@@ -115,12 +119,45 @@ export const aggregateProjectTimes = (payload: RescueTimeProjectTimesPayload) =>
   return { byName, byClientId };
 };
 
-export const overviewSecondsForGoal = (
-  payload: RescueTimeAnalyticPayload,
-  goal: RescueTimeGoalRecord
+export const resolveAnalyticKind = (goal: RescueTimeGoalRecord): string => {
+  const taxonomy = goal.taxonomy?.search_name ?? goal.taxonomy_name ?? "";
+  if (taxonomy === "productivity") {
+    return "productivity";
+  }
+  if (taxonomy === "category") {
+    return "category";
+  }
+  if (taxonomy === "activity") {
+    return "activity";
+  }
+  return "overview";
+};
+
+export const matchRankRowSeconds = (
+  rows: ReturnType<typeof parseRankRows>,
+  goal: RescueTimeGoalRecord,
+  kind: string
 ): number => {
-  const rows = parseRankRows(payload);
-  const needle = (goal.overview?.name ?? goal.taxon_display_name ?? "").toLowerCase();
-  const row = rows.find((item) => item.name.toLowerCase() === needle || item.name.toLowerCase().includes(needle));
+  const needle = (
+    goal.taxon_display_name ??
+    goal.overview?.name ??
+    goal.v2project?.name ??
+    goal.productivity?.display_name ??
+    goal.productivity?.name ??
+    ""
+  ).toLowerCase();
+
+  if (!needle) {
+    return 0;
+  }
+
+  const row = rows.find((item) => {
+    const name = item.name.toLowerCase();
+    return name === needle || name.includes(needle) || needle.includes(name);
+  });
+
   return row?.seconds ?? 0;
 };
+
+export const goalScheduleId = (goal: RescueTimeGoalRecord): number =>
+  Number(goal.schedule_id ?? goal.schedule?.id ?? 0);

--- a/src/lib/rescuetime/goals-client.ts
+++ b/src/lib/rescuetime/goals-client.ts
@@ -1,0 +1,126 @@
+import type { RescueTimeGoalRecord } from "../../domain/rescuetime-goals";
+import type { RescueTimeAnalyticPayload } from "./parse-analytic-data";
+import { parseRankRows } from "./parse-analytic-data";
+
+export interface RescueTimeProjectTimesPayload {
+  project_times?: Array<{
+    duration?: number;
+    project?: {
+      id?: number;
+      name?: string;
+      timesheets_client_id?: number;
+    };
+  }>;
+}
+
+export interface RescueTimeGoalsClient {
+  listGoals(apiKey: string): Promise<RescueTimeGoalRecord[]>;
+  fetchAnalyticData(apiKey: string, kind: string, begin: string, end: string): Promise<RescueTimeAnalyticPayload>;
+  fetchProjectTimes(apiKey: string, begin: string, end: string): Promise<RescueTimeProjectTimesPayload>;
+}
+
+export class HttpRescueTimeGoalsClient implements RescueTimeGoalsClient {
+  private async fetchJson<T>(apiKey: string, url: string): Promise<T> {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`
+      }
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`RescueTime API ${response.status}: ${body.slice(0, 200)}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  async listGoals(apiKey: string): Promise<RescueTimeGoalRecord[]> {
+    const goals = await this.fetchJson<RescueTimeGoalRecord[]>(
+      apiKey,
+      "https://www.rescuetime.com/api/resource/goals"
+    );
+    return goals.filter((goal) => goal.enabled !== false);
+  }
+
+  async fetchAnalyticData(
+    apiKey: string,
+    kind: string,
+    begin: string,
+    end: string
+  ): Promise<RescueTimeAnalyticPayload> {
+    const url = new URL("https://www.rescuetime.com/anapi/data");
+    url.searchParams.set("format", "json");
+    url.searchParams.set("perspective", "rank");
+    url.searchParams.set("restrict_kind", kind);
+    url.searchParams.set("restrict_begin", begin);
+    url.searchParams.set("restrict_end", end);
+    return this.fetchJson(apiKey, url.toString());
+  }
+
+  async fetchProjectTimes(apiKey: string, begin: string, end: string): Promise<RescueTimeProjectTimesPayload> {
+    const url = new URL("https://www.rescuetime.com/api/resource/labeled_time_project_times");
+    url.searchParams.set("start_date", begin);
+    url.searchParams.set("end_date", end);
+    return this.fetchJson(apiKey, url.toString());
+  }
+}
+
+export const defaultRescueTimeGoalsClient = new HttpRescueTimeGoalsClient();
+
+export interface ParsedProductivityRow {
+  productivity: number;
+  seconds: number;
+}
+
+export const parseProductivityRows = (payload: RescueTimeAnalyticPayload): ParsedProductivityRow[] => {
+  const headers = payload.row_headers ?? [];
+  const secondsIndex = headers.findIndex((header) => String(header).toLowerCase().includes("time spent"));
+  const productivityIndex = headers.findIndex((header) => String(header).toLowerCase() === "productivity");
+
+  return (payload.rows ?? []).map((row) => ({
+    productivity: Number(row[productivityIndex] ?? 0),
+    seconds: Number(row[secondsIndex] ?? 0)
+  }));
+};
+
+export const productivitySecondsForGoal = (rows: ParsedProductivityRow[], goal: RescueTimeGoalRecord): number => {
+  const productivityId = goal.productivity?.id ?? goal.taxon_id;
+  if (productivityId === 7) {
+    return rows.filter((row) => row.productivity < 0).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (productivityId === 10) {
+    return rows.reduce((sum, row) => sum + row.seconds, 0);
+  }
+  return 0;
+};
+
+export const aggregateProjectTimes = (payload: RescueTimeProjectTimesPayload) => {
+  const byName = new Map<string, number>();
+  const byClientId = new Map<number, number>();
+
+  for (const entry of payload.project_times ?? []) {
+    const projectName = (entry.project?.name ?? "").toLowerCase().trim();
+    const clientId = entry.project?.timesheets_client_id;
+    const duration = Number(entry.duration ?? 0);
+
+    if (projectName) {
+      byName.set(projectName, (byName.get(projectName) ?? 0) + duration);
+    }
+    if (clientId) {
+      byClientId.set(clientId, (byClientId.get(clientId) ?? 0) + duration);
+    }
+  }
+
+  return { byName, byClientId };
+};
+
+export const overviewSecondsForGoal = (
+  payload: RescueTimeAnalyticPayload,
+  goal: RescueTimeGoalRecord
+): number => {
+  const rows = parseRankRows(payload);
+  const needle = (goal.overview?.name ?? goal.taxon_display_name ?? "").toLowerCase();
+  const row = rows.find((item) => item.name.toLowerCase() === needle || item.name.toLowerCase().includes(needle));
+  return row?.seconds ?? 0;
+};

--- a/src/lib/rescuetime/http-transport.ts
+++ b/src/lib/rescuetime/http-transport.ts
@@ -1,0 +1,22 @@
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "../storage/factory";
+
+export const fetchRescueTimeJson = async <T>(url: string, apiKey: string): Promise<T> => {
+  if (isTauriRuntime()) {
+    const body = await invoke<string>("rescuetime_http_get", { url, apiKey });
+    return JSON.parse(body) as T;
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`
+    }
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`RescueTime API ${response.status}: ${errorBody.slice(0, 200)}`);
+  }
+
+  return response.json() as Promise<T>;
+};

--- a/src/lib/rescuetime/parse-analytic-data.test.ts
+++ b/src/lib/rescuetime/parse-analytic-data.test.ts
@@ -1,0 +1,32 @@
+import { parseRankRows, resolveObjectiveSeconds } from "./parse-analytic-data";
+
+describe("parseRankRows", () => {
+  it("uses the Category column for names when present", () => {
+    const rows = parseRankRows({
+      row_headers: ["Rank", "Time Spent (seconds)", "Number of People", "Category"],
+      rows: [
+        [1, 7200, 1, "Software Development"],
+        [2, 3600, 1, "Professional Networking"]
+      ]
+    });
+
+    expect(rows).toEqual([
+      { name: "Software Development", seconds: 7200, hours: 2 },
+      { name: "Professional Networking", seconds: 3600, hours: 1 }
+    ]);
+  });
+
+  it("resolves a specific thing or sums all rows", () => {
+    const rows = parseRankRows({
+      row_headers: ["Rank", "Time Spent (seconds)", "Category"],
+      rows: [
+        [1, 7200, "Software Development"],
+        [2, 3600, "Professional Networking"]
+      ]
+    });
+
+    expect(resolveObjectiveSeconds(rows, "Software Development")).toBe(7200);
+    expect(resolveObjectiveSeconds(rows, "Missing Category")).toBe(0);
+    expect(resolveObjectiveSeconds(rows, null)).toBe(10800);
+  });
+});

--- a/src/lib/rescuetime/parse-analytic-data.ts
+++ b/src/lib/rescuetime/parse-analytic-data.ts
@@ -1,0 +1,75 @@
+export interface RescueTimeAnalyticPayload {
+  row_headers?: unknown[];
+  rows?: unknown[][];
+}
+
+export interface ParsedRescueTimeRow {
+  name: string;
+  seconds: number;
+  hours: number;
+}
+
+const findSecondsColumnIndex = (rowHeaders: unknown[]): number => {
+  const normalized = rowHeaders.map((header) => String(header).toLowerCase());
+  const candidates = ["time spent (seconds)", "time spent", "seconds", "time_spent_seconds"];
+
+  for (const candidate of candidates) {
+    const index = normalized.findIndex(
+      (header) => header.includes(candidate.replace(/_/g, " ")) || header === candidate
+    );
+    if (index >= 0) {
+      return index;
+    }
+  }
+
+  return normalized.findIndex((header) => header.includes("second"));
+};
+
+const findNameColumnIndex = (rowHeaders: unknown[]): number => {
+  const normalized = rowHeaders.map((header) => String(header).toLowerCase());
+  const categoryIndex = normalized.findIndex((header) => header === "category");
+  if (categoryIndex >= 0) {
+    return categoryIndex;
+  }
+
+  const activityIndex = normalized.findIndex((header) => header.includes("activity"));
+  if (activityIndex >= 0) {
+    return activityIndex;
+  }
+
+  return normalized.length > 1 ? normalized.length - 1 : 1;
+};
+
+export const parseRankRows = (payload: RescueTimeAnalyticPayload): ParsedRescueTimeRow[] => {
+  const headers = payload.row_headers ?? [];
+  const secondsIndex = findSecondsColumnIndex(headers);
+  const nameIndex = findNameColumnIndex(headers);
+
+  if (secondsIndex < 0) {
+    throw new Error(`Could not locate seconds column in headers: ${headers.join(", ")}`);
+  }
+
+  const rows = (payload.rows ?? []).map((row) => {
+    const name = String(row[nameIndex] ?? row[1] ?? "unknown");
+    const seconds = Number(row[secondsIndex] ?? 0);
+    return {
+      name,
+      seconds,
+      hours: seconds / 3600
+    };
+  });
+
+  return rows.sort((left, right) => right.seconds - left.seconds);
+};
+
+export const resolveObjectiveSeconds = (
+  rows: ParsedRescueTimeRow[],
+  thing: string | null
+): number => {
+  if (thing) {
+    const match = rows.find((row) => row.name === thing);
+    return match?.seconds ?? 0;
+  }
+
+  return rows.reduce((sum, row) => sum + row.seconds, 0);
+};

--- a/src/lib/rescuetime/productivity-mapping.test.ts
+++ b/src/lib/rescuetime/productivity-mapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { productivitySecondsForGoal } from "./productivity-mapping";
+import { computeProductivityPulse, productivitySecondsForGoal } from "./productivity-mapping";
 
 describe("productivitySecondsForGoal", () => {
   const rows = [
@@ -47,5 +47,36 @@ describe("productivitySecondsForGoal", () => {
         productivity: { id: 2, name: "very productive", display_name: "Focus Work" }
       })
     ).toBe(3600);
+  });
+});
+
+describe("computeProductivityPulse", () => {
+  it("returns a time-weighted pulse on a 0-100 scale", () => {
+    expect(
+      computeProductivityPulse([
+        { productivity: 2, seconds: 3600 },
+        { productivity: 0, seconds: 3600 }
+      ])
+    ).toBe(75);
+  });
+
+  it("returns null when no tracked seconds remain", () => {
+    expect(computeProductivityPulse([])).toBeNull();
+    expect(computeProductivityPulse([{ productivity: 1, seconds: 0 }])).toBeNull();
+  });
+
+  it("skips rows with non-finite values", () => {
+    expect(
+      computeProductivityPulse([
+        { productivity: Number.NaN, seconds: 3600 },
+        { productivity: 2, seconds: Number.POSITIVE_INFINITY },
+        { productivity: 1, seconds: 1800 }
+      ])
+    ).toBe(75);
+  });
+
+  it("clamps pulse to 0-100", () => {
+    expect(computeProductivityPulse([{ productivity: 2, seconds: 3600 }])).toBe(100);
+    expect(computeProductivityPulse([{ productivity: -2, seconds: 3600 }])).toBe(0);
   });
 });

--- a/src/lib/rescuetime/productivity-mapping.test.ts
+++ b/src/lib/rescuetime/productivity-mapping.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { productivitySecondsForGoal } from "./productivity-mapping";
+
+describe("productivitySecondsForGoal", () => {
+  const rows = [
+    { productivity: 2, seconds: 3600 },
+    { productivity: 1, seconds: 1800 },
+    { productivity: 0, seconds: 900 },
+    { productivity: -1, seconds: 600 },
+    { productivity: -2, seconds: 300 }
+  ];
+
+  it("sums all distracting time for aggregate id 7", () => {
+    expect(
+      productivitySecondsForGoal(rows, {
+        id: 1,
+        display_name: "less distracting",
+        amount_seconds: 3600,
+        is_more: false,
+        taxon_id: 7,
+        productivity: { id: 7, sql_score_equals: "< 0" }
+      })
+    ).toBe(900);
+  });
+
+  it("sums all time for aggregate id 10", () => {
+    expect(
+      productivitySecondsForGoal(rows, {
+        id: 2,
+        display_name: "all time",
+        amount_seconds: 3600,
+        is_more: false,
+        taxon_id: 10,
+        productivity: { id: 10, sql_score_equals: "BETWEEN -2 and 2" }
+      })
+    ).toBe(7200);
+  });
+
+  it("matches individual focus-work goals by productivity name", () => {
+    expect(
+      productivitySecondsForGoal(rows, {
+        id: 3,
+        display_name: "more focus work",
+        amount_seconds: 3600,
+        is_more: true,
+        taxon_id: 2,
+        productivity: { id: 2, name: "very productive", display_name: "Focus Work" }
+      })
+    ).toBe(3600);
+  });
+});

--- a/src/lib/rescuetime/productivity-mapping.ts
+++ b/src/lib/rescuetime/productivity-mapping.ts
@@ -1,0 +1,79 @@
+import type { RescueTimeGoalRecord } from "../../domain/rescuetime-goals";
+
+export interface ParsedProductivityRow {
+  productivity: number;
+  seconds: number;
+}
+
+const productivityScoreFromName = (name: string | undefined): number | null => {
+  const normalized = (name ?? "").toLowerCase();
+  if (normalized.includes("very productive") || normalized.includes("focus work")) {
+    return 2;
+  }
+  if (normalized.includes("other work") || (normalized.includes("productive") && !normalized.includes("distracting"))) {
+    return 1;
+  }
+  if (normalized.includes("neutral")) {
+    return 0;
+  }
+  if (normalized.includes("very distracting")) {
+    return -2;
+  }
+  if (normalized.includes("personal") || normalized.includes("distracting")) {
+    return -1;
+  }
+  return null;
+};
+
+const productivityScoresFromSqlEquals = (sqlEquals: string | undefined): number[] | null => {
+  const normalized = (sqlEquals ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.includes("< 0")) {
+    return [-2, -1];
+  }
+  if (normalized.includes("between -2 and 2")) {
+    return [2, 1, 0, -1, -2];
+  }
+  const exactMatch = normalized.match(/=\s*(-?\d+)/);
+  if (exactMatch) {
+    return [Number(exactMatch[1])];
+  }
+  return null;
+};
+
+export const productivitySecondsForGoal = (
+  rows: ParsedProductivityRow[],
+  goal: RescueTimeGoalRecord
+): number => {
+  const productivity = goal.productivity;
+  const productivityId = productivity?.id ?? goal.taxon_id;
+
+  if (productivityId === 7) {
+    return rows.filter((row) => row.productivity < 0).reduce((sum, row) => sum + row.seconds, 0);
+  }
+  if (productivityId === 10) {
+    return rows.reduce((sum, row) => sum + row.seconds, 0);
+  }
+
+  const sqlScores = productivityScoresFromSqlEquals(
+    (productivity as { sql_score_equals?: string } | undefined)?.sql_score_equals
+  );
+  if (sqlScores) {
+    return rows
+      .filter((row) => sqlScores.includes(row.productivity))
+      .reduce((sum, row) => sum + row.seconds, 0);
+  }
+
+  const scoreFromName = productivityScoreFromName(productivity?.name ?? productivity?.display_name);
+  if (scoreFromName !== null) {
+    return rows
+      .filter((row) => row.productivity === scoreFromName)
+      .reduce((sum, row) => sum + row.seconds, 0);
+  }
+
+  return rows
+    .filter((row) => row.productivity === productivityId)
+    .reduce((sum, row) => sum + row.seconds, 0);
+};

--- a/src/lib/rescuetime/productivity-mapping.ts
+++ b/src/lib/rescuetime/productivity-mapping.ts
@@ -77,3 +77,25 @@ export const productivitySecondsForGoal = (
     .filter((row) => row.productivity === productivityId)
     .reduce((sum, row) => sum + row.seconds, 0);
 };
+
+export const computeProductivityPulse = (rows: ParsedProductivityRow[]): number | null => {
+  let weightedSum = 0;
+  let totalSeconds = 0;
+
+  for (const row of rows) {
+    if (!Number.isFinite(row.seconds) || !Number.isFinite(row.productivity)) {
+      continue;
+    }
+
+    weightedSum += row.productivity * row.seconds;
+    totalSeconds += row.seconds;
+  }
+
+  if (totalSeconds <= 0) {
+    return null;
+  }
+
+  const mean = weightedSum / totalSeconds;
+  const pulse = ((mean + 2) / 4) * 100;
+  return Math.min(100, Math.max(0, pulse));
+};

--- a/src/lib/rescuetime/rescuetime-goals-service.test.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.test.ts
@@ -1,0 +1,55 @@
+import { MemoryRepository } from "../storage/memory-repository";
+import type { RescueTimeGoalsClient } from "./goals-client";
+import { RescueTimeGoalsService } from "./rescuetime-goals-service";
+
+describe("RescueTimeGoalsService", () => {
+  it("scores enabled RescueTime goals for a week", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
+    });
+
+    const mockClient: RescueTimeGoalsClient = {
+      listGoals: vi.fn(async () => [
+        {
+          id: 1,
+          display_name: "more than 2h on Personal (24x7)",
+          amount_seconds: 7200,
+          is_more: true,
+          enabled: true,
+          taxon_id: 15,
+          taxonomy_name: "overview",
+          schedule_name: "24x7",
+          overview: { name: "Personal" }
+        }
+      ]),
+      fetchAnalyticData: vi.fn(async () => ({
+        row_headers: ["Rank", "Time Spent (seconds)", "Category"],
+        rows: [[1, 12600, "Personal"]]
+      })),
+      fetchProjectTimes: vi.fn(async () => ({ project_times: [] }))
+    };
+
+    const service = new RescueTimeGoalsService(repository, mockClient);
+    const snapshot = await service.computeGoalsSnapshot("2026-08-02");
+
+    expect(mockClient.listGoals).toHaveBeenCalledWith("rt-test-key");
+    expect(snapshot.fetchError).toBeUndefined();
+    expect(snapshot.score).toBe(0.25);
+    expect(snapshot.items).toHaveLength(1);
+    expect(snapshot.items[0]).toMatchObject({
+      title: "more than 2h on Personal (24x7)",
+      achievement: 0.25
+    });
+    expect(mockClient.fetchAnalyticData).toHaveBeenCalledWith(
+      "rt-test-key",
+      expect.objectContaining({
+        kind: "overview",
+        begin: "2026-08-02",
+        end: "2026-08-08"
+      })
+    );
+  });
+});

--- a/src/lib/rescuetime/rescuetime-goals-service.test.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.test.ts
@@ -52,4 +52,51 @@ describe("RescueTimeGoalsService", () => {
       })
     );
   });
+
+  it("computes productivity pulse for a week without schedule filter", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
+    });
+
+    const mockClient: RescueTimeGoalsClient = {
+      listGoals: vi.fn(async () => []),
+      fetchAnalyticData: vi.fn(async () => ({
+        row_headers: ["Rank", "Time Spent (seconds)", "Productivity"],
+        rows: [
+          [1, 3600, 2],
+          [2, 3600, 0]
+        ]
+      })),
+      fetchProjectTimes: vi.fn(async () => ({ project_times: [] }))
+    };
+
+    const service = new RescueTimeGoalsService(repository, mockClient);
+    const snapshot = await service.computeProductivityPulse("2026-08-02");
+
+    expect(mockClient.fetchAnalyticData).toHaveBeenCalledWith(
+      "rt-test-key",
+      expect.objectContaining({
+        kind: "productivity",
+        begin: "2026-08-02",
+        end: "2026-08-08"
+      })
+    );
+    expect(snapshot.weekStartDate).toBe("2026-08-02");
+    expect(snapshot.pulse).toBe(75);
+    expect(snapshot.fetchError).toBeUndefined();
+  });
+
+  it("returns null pulse when RescueTime is not configured", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const service = new RescueTimeGoalsService(repository);
+    const snapshot = await service.computeProductivityPulse("2026-08-02");
+
+    expect(snapshot.rescuetimeConfigured).toBe(false);
+    expect(snapshot.pulse).toBeNull();
+  });
 });

--- a/src/lib/rescuetime/rescuetime-goals-service.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.ts
@@ -22,6 +22,7 @@ import {
   resolveAnalyticKind,
   type RescueTimeGoalsClient
 } from "./goals-client";
+import { computeProductivityPulse } from "./productivity-mapping";
 
 interface AnalyticCache {
   productivity: Map<number, ReturnType<typeof parseProductivityRows>>;
@@ -36,6 +37,14 @@ const createAnalyticCache = (): AnalyticCache => ({
   category: new Map(),
   activity: new Map()
 });
+
+export interface RescueTimeProductivityPulseSnapshot {
+  weekStartDate: string;
+  weekEndDate: string;
+  pulse: number | null;
+  rescuetimeConfigured: boolean;
+  fetchError?: string;
+}
 
 export class RescueTimeGoalsService {
   constructor(
@@ -179,6 +188,50 @@ export class RescueTimeGoalsService {
     const rankKind = analyticKind as "overview" | "category" | "activity";
     const rows = await this.loadRankRows(apiKey, rankKind, weekStart, weekEnd, scheduleId, caches);
     return matchRankRowSeconds(rows, goal, rankKind);
+  }
+
+  async computeProductivityPulse(weekStartDate: string): Promise<RescueTimeProductivityPulseSnapshot> {
+    const normalized = buildWeekDates(weekStartDate);
+    const weekEndDate = addDays(normalized, 6);
+    const settings = await this.repository.getSettings();
+    const apiKey = settings.rescuetimeApiKey.trim();
+    const rescuetimeConfigured = apiKey.length > 0;
+
+    if (!rescuetimeConfigured) {
+      return {
+        weekStartDate: normalized,
+        weekEndDate,
+        pulse: null,
+        rescuetimeConfigured
+      };
+    }
+
+    try {
+      const payload = await this.client.fetchAnalyticData(apiKey, {
+        kind: "productivity",
+        begin: normalized,
+        end: weekEndDate
+      });
+      const rows = parseProductivityRows(payload);
+      const pulse = computeProductivityPulse(rows);
+
+      return {
+        weekStartDate: normalized,
+        weekEndDate,
+        pulse,
+        rescuetimeConfigured
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Echec de la requete RescueTime productivity.";
+      return {
+        weekStartDate: normalized,
+        weekEndDate,
+        pulse: null,
+        rescuetimeConfigured,
+        fetchError: message
+      };
+    }
   }
 
   async testConnection(apiKey: string): Promise<{ goalCount: number; sampleGoal?: string }> {

--- a/src/lib/rescuetime/rescuetime-goals-service.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.ts
@@ -14,17 +14,28 @@ import type { AppRepository } from "../storage/repository";
 import {
   aggregateProjectTimes,
   defaultRescueTimeGoalsClient,
+  goalScheduleId,
+  matchRankRowSeconds,
   parseProductivityRows,
+  parseRankRows,
   productivitySecondsForGoal,
+  resolveAnalyticKind,
   type RescueTimeGoalsClient
 } from "./goals-client";
-import { parseRankRows } from "./parse-analytic-data";
 
-interface FetchCaches {
-  productivity?: ReturnType<typeof parseProductivityRows>;
-  overview?: ReturnType<typeof import("./parse-analytic-data").parseRankRows>;
-  projectTimes?: ReturnType<typeof aggregateProjectTimes>;
+interface AnalyticCache {
+  productivity: Map<number, ReturnType<typeof parseProductivityRows>>;
+  overview: Map<number, ReturnType<typeof parseRankRows>>;
+  category: Map<number, ReturnType<typeof parseRankRows>>;
+  activity: Map<number, ReturnType<typeof parseRankRows>>;
 }
+
+const createAnalyticCache = (): AnalyticCache => ({
+  productivity: new Map(),
+  overview: new Map(),
+  category: new Map(),
+  activity: new Map()
+});
 
 export class RescueTimeGoalsService {
   constructor(
@@ -45,14 +56,28 @@ export class RescueTimeGoalsService {
 
     try {
       const goals = await this.client.listGoals(apiKey);
-      const caches: FetchCaches = {};
+      const caches = createAnalyticCache();
+      let projectTimesCache: ReturnType<typeof aggregateProjectTimes> | undefined;
       const items: RescueTimeGoalItemSnapshot[] = [];
 
       for (const goal of goals) {
         const scheduleLabel = goal.schedule?.name ?? goal.schedule_name ?? "24x7";
         const days = scheduleDaysInWeek(scheduleLabel);
         const weeklyTargetSeconds = Number(goal.amount_seconds ?? 0) * days;
-        const actualSeconds = await this.resolveActualSeconds(apiKey, goal, normalized, weekEndDate, caches);
+        const actualSeconds = await this.resolveActualSeconds(
+          apiKey,
+          goal,
+          normalized,
+          weekEndDate,
+          caches,
+          async () => {
+            if (!projectTimesCache) {
+              const payload = await this.client.fetchProjectTimes(apiKey, normalized, weekEndDate);
+              projectTimesCache = aggregateProjectTimes(payload);
+            }
+            return projectTimesCache;
+          }
+        );
         const achievement = goal.is_more
           ? scoreMoreGoal(actualSeconds, weeklyTargetSeconds)
           : scoreLessGoal(actualSeconds, weeklyTargetSeconds);
@@ -78,22 +103,61 @@ export class RescueTimeGoalsService {
     }
   }
 
+  private async loadProductivityRows(
+    apiKey: string,
+    weekStart: string,
+    weekEnd: string,
+    scheduleId: number,
+    caches: AnalyticCache
+  ) {
+    if (!caches.productivity.has(scheduleId)) {
+      const payload = await this.client.fetchAnalyticData(apiKey, {
+        kind: "productivity",
+        begin: weekStart,
+        end: weekEnd,
+        scheduleId
+      });
+      caches.productivity.set(scheduleId, parseProductivityRows(payload));
+    }
+    return caches.productivity.get(scheduleId)!;
+  }
+
+  private async loadRankRows(
+    apiKey: string,
+    kind: "overview" | "category" | "activity",
+    weekStart: string,
+    weekEnd: string,
+    scheduleId: number,
+    caches: AnalyticCache
+  ) {
+    const cacheMap = caches[kind];
+    if (!cacheMap.has(scheduleId)) {
+      const payload = await this.client.fetchAnalyticData(apiKey, {
+        kind,
+        begin: weekStart,
+        end: weekEnd,
+        scheduleId
+      });
+      cacheMap.set(scheduleId, parseRankRows(payload));
+    }
+    return cacheMap.get(scheduleId)!;
+  }
+
   private async resolveActualSeconds(
     apiKey: string,
     goal: RescueTimeGoalRecord,
     weekStart: string,
     weekEnd: string,
-    caches: FetchCaches
+    caches: AnalyticCache,
+    ensureProjectTimesCache: () => Promise<ReturnType<typeof aggregateProjectTimes>>
   ): Promise<number> {
     const taxonomy = goal.taxonomy?.search_name ?? goal.taxonomy_name ?? "";
+    const scheduleId = goalScheduleId(goal);
 
     if (taxonomy === "projects" || goal.v2project) {
-      if (!caches.projectTimes) {
-        const payload = await this.client.fetchProjectTimes(apiKey, weekStart, weekEnd);
-        caches.projectTimes = aggregateProjectTimes(payload);
-      }
+      const projectTimes = await ensureProjectTimesCache();
       const label = goal.v2project?.name ?? goal.taxon_display_name ?? "";
-      for (const [name, seconds] of caches.projectTimes.byName) {
+      for (const [name, seconds] of projectTimes.byName) {
         if (rescueTimeLabelsMatch(name, label)) {
           return seconds;
         }
@@ -102,34 +166,19 @@ export class RescueTimeGoalsService {
     }
 
     if (taxonomy === "clients") {
-      if (!caches.projectTimes) {
-        const payload = await this.client.fetchProjectTimes(apiKey, weekStart, weekEnd);
-        caches.projectTimes = aggregateProjectTimes(payload);
-      }
-      return caches.projectTimes.byClientId.get(goal.taxon_id) ?? 0;
+      const projectTimes = await ensureProjectTimesCache();
+      return projectTimes.byClientId.get(goal.taxon_id) ?? 0;
     }
 
-    if (taxonomy === "productivity") {
-      if (!caches.productivity) {
-        const payload = await this.client.fetchAnalyticData(apiKey, "productivity", weekStart, weekEnd);
-        caches.productivity = parseProductivityRows(payload);
-      }
-      return productivitySecondsForGoal(caches.productivity, goal);
+    const analyticKind = resolveAnalyticKind(goal);
+    if (analyticKind === "productivity") {
+      const rows = await this.loadProductivityRows(apiKey, weekStart, weekEnd, scheduleId, caches);
+      return productivitySecondsForGoal(rows, goal);
     }
 
-    if (taxonomy === "category" || taxonomy === "overviews" || taxonomy === "overview" || goal.overview) {
-      if (!caches.overview) {
-        const payload = await this.client.fetchAnalyticData(apiKey, "overview", weekStart, weekEnd);
-        caches.overview = parseRankRows(payload);
-      }
-      const needle = (goal.overview?.name ?? goal.taxon_display_name ?? "").toLowerCase();
-      const row = caches.overview.find(
-        (item) => item.name.toLowerCase() === needle || item.name.toLowerCase().includes(needle)
-      );
-      return row?.seconds ?? 0;
-    }
-
-    return 0;
+    const rankKind = analyticKind as "overview" | "category" | "activity";
+    const rows = await this.loadRankRows(apiKey, rankKind, weekStart, weekEnd, scheduleId, caches);
+    return matchRankRowSeconds(rows, goal, rankKind);
   }
 
   async testConnection(apiKey: string): Promise<{ goalCount: number; sampleGoal?: string }> {

--- a/src/lib/rescuetime/rescuetime-goals-service.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.ts
@@ -1,0 +1,147 @@
+import { addDays } from "../gtd/shared";
+import {
+  computeRescueTimeGoalsSnapshot,
+  rescueTimeLabelsMatch,
+  scheduleDaysInWeek,
+  scoreLessGoal,
+  scoreMoreGoal,
+  type RescueTimeGoalItemSnapshot,
+  type RescueTimeGoalRecord,
+  type RescueTimeGoalsSnapshot
+} from "../../domain/rescuetime-goals";
+import { buildWeekDates } from "../../domain/weekly-review";
+import type { AppRepository } from "../storage/repository";
+import {
+  aggregateProjectTimes,
+  defaultRescueTimeGoalsClient,
+  parseProductivityRows,
+  productivitySecondsForGoal,
+  type RescueTimeGoalsClient
+} from "./goals-client";
+import { parseRankRows } from "./parse-analytic-data";
+
+interface FetchCaches {
+  productivity?: ReturnType<typeof parseProductivityRows>;
+  overview?: ReturnType<typeof import("./parse-analytic-data").parseRankRows>;
+  projectTimes?: ReturnType<typeof aggregateProjectTimes>;
+}
+
+export class RescueTimeGoalsService {
+  constructor(
+    private readonly repository: AppRepository,
+    private readonly client: RescueTimeGoalsClient = defaultRescueTimeGoalsClient
+  ) {}
+
+  async computeGoalsSnapshot(weekStartDate: string): Promise<RescueTimeGoalsSnapshot> {
+    const normalized = buildWeekDates(weekStartDate);
+    const weekEndDate = addDays(normalized, 6);
+    const settings = await this.repository.getSettings();
+    const apiKey = settings.rescuetimeApiKey.trim();
+    const rescuetimeConfigured = apiKey.length > 0;
+
+    if (!rescuetimeConfigured) {
+      return computeRescueTimeGoalsSnapshot(normalized, weekEndDate, [], { rescuetimeConfigured });
+    }
+
+    try {
+      const goals = await this.client.listGoals(apiKey);
+      const caches: FetchCaches = {};
+      const items: RescueTimeGoalItemSnapshot[] = [];
+
+      for (const goal of goals) {
+        const scheduleLabel = goal.schedule?.name ?? goal.schedule_name ?? "24x7";
+        const days = scheduleDaysInWeek(scheduleLabel);
+        const weeklyTargetSeconds = Number(goal.amount_seconds ?? 0) * days;
+        const actualSeconds = await this.resolveActualSeconds(apiKey, goal, normalized, weekEndDate, caches);
+        const achievement = goal.is_more
+          ? scoreMoreGoal(actualSeconds, weeklyTargetSeconds)
+          : scoreLessGoal(actualSeconds, weeklyTargetSeconds);
+
+        items.push({
+          goalId: goal.id,
+          title: goal.display_name,
+          isMore: goal.is_more,
+          actualHours: actualSeconds / 3600,
+          weeklyTargetHours: weeklyTargetSeconds / 3600,
+          achievement,
+          scheduleLabel
+        });
+      }
+
+      return computeRescueTimeGoalsSnapshot(normalized, weekEndDate, items, { rescuetimeConfigured });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Echec de la requete RescueTime Goals.";
+      return computeRescueTimeGoalsSnapshot(normalized, weekEndDate, [], {
+        rescuetimeConfigured,
+        fetchError: message
+      });
+    }
+  }
+
+  private async resolveActualSeconds(
+    apiKey: string,
+    goal: RescueTimeGoalRecord,
+    weekStart: string,
+    weekEnd: string,
+    caches: FetchCaches
+  ): Promise<number> {
+    const taxonomy = goal.taxonomy?.search_name ?? goal.taxonomy_name ?? "";
+
+    if (taxonomy === "projects" || goal.v2project) {
+      if (!caches.projectTimes) {
+        const payload = await this.client.fetchProjectTimes(apiKey, weekStart, weekEnd);
+        caches.projectTimes = aggregateProjectTimes(payload);
+      }
+      const label = goal.v2project?.name ?? goal.taxon_display_name ?? "";
+      for (const [name, seconds] of caches.projectTimes.byName) {
+        if (rescueTimeLabelsMatch(name, label)) {
+          return seconds;
+        }
+      }
+      return 0;
+    }
+
+    if (taxonomy === "clients") {
+      if (!caches.projectTimes) {
+        const payload = await this.client.fetchProjectTimes(apiKey, weekStart, weekEnd);
+        caches.projectTimes = aggregateProjectTimes(payload);
+      }
+      return caches.projectTimes.byClientId.get(goal.taxon_id) ?? 0;
+    }
+
+    if (taxonomy === "productivity") {
+      if (!caches.productivity) {
+        const payload = await this.client.fetchAnalyticData(apiKey, "productivity", weekStart, weekEnd);
+        caches.productivity = parseProductivityRows(payload);
+      }
+      return productivitySecondsForGoal(caches.productivity, goal);
+    }
+
+    if (taxonomy === "category" || taxonomy === "overviews" || taxonomy === "overview" || goal.overview) {
+      if (!caches.overview) {
+        const payload = await this.client.fetchAnalyticData(apiKey, "overview", weekStart, weekEnd);
+        caches.overview = parseRankRows(payload);
+      }
+      const needle = (goal.overview?.name ?? goal.taxon_display_name ?? "").toLowerCase();
+      const row = caches.overview.find(
+        (item) => item.name.toLowerCase() === needle || item.name.toLowerCase().includes(needle)
+      );
+      return row?.seconds ?? 0;
+    }
+
+    return 0;
+  }
+
+  async testConnection(apiKey: string): Promise<{ goalCount: number; sampleGoal?: string }> {
+    const trimmed = apiKey.trim();
+    if (!trimmed) {
+      throw new Error("Cle API RescueTime manquante.");
+    }
+
+    const goals = await this.client.listGoals(trimmed);
+    return {
+      goalCount: goals.length,
+      sampleGoal: goals[0]?.display_name
+    };
+  }
+}

--- a/src/lib/rescuetime/weekly-objectives-service.test.ts
+++ b/src/lib/rescuetime/weekly-objectives-service.test.ts
@@ -1,0 +1,65 @@
+import { createEmptyWeeklyObjective } from "../../domain/weekly-objectives";
+import { MemoryRepository } from "../storage/memory-repository";
+import { WeeklyObjectivesService } from "./weekly-objectives-service";
+import type { RescueTimeClient } from "./client";
+
+describe("WeeklyObjectivesService", () => {
+  it("computes a snapshot from repository data and a mocked RescueTime client", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const objective = await repository.saveWeeklyObjective(
+      createEmptyWeeklyObjective({
+        title: "Software Development",
+        kind: "time",
+        targetHours: 2,
+        rescuetimeKind: "category",
+        rescuetimeThing: "Software Development"
+      })
+    );
+
+    await repository.saveWeeklyObjective(
+      createEmptyWeeklyObjective({
+        title: "Budget review",
+        kind: "manual"
+      })
+    );
+
+    await repository.saveWeeklyObjectiveResult({
+      weekStartDate: "2026-08-02",
+      objectiveId: (await repository.listWeeklyObjectives()).find((item) => item.kind === "manual")!.id,
+      achieved: true,
+      updatedAt: "2026-08-09T12:00:00.000Z"
+    });
+
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
+    });
+
+    const mockClient: RescueTimeClient = {
+      fetchAnalyticData: vi.fn(async () => ({
+        row_headers: ["Rank", "Time Spent (seconds)", "Category"],
+        rows: [[1, 3600, "Software Development"]]
+      }))
+    };
+
+    const service = new WeeklyObjectivesService(repository, mockClient);
+    const snapshot = await service.computeWeeklyObjectivesSnapshot("2026-08-02");
+
+    expect(snapshot.score).toBe(0.75);
+    expect(snapshot.items.find((item) => item.objective.id === objective.id)).toMatchObject({
+      actualHours: 1,
+      achievement: 0.5,
+      source: "rescuetime"
+    });
+    expect(mockClient.fetchAnalyticData).toHaveBeenCalledWith(
+      "rt-test-key",
+      expect.objectContaining({
+        kind: "category",
+        begin: "2026-08-02",
+        end: "2026-08-08"
+      })
+    );
+  });
+});

--- a/src/lib/rescuetime/weekly-objectives-service.ts
+++ b/src/lib/rescuetime/weekly-objectives-service.ts
@@ -1,0 +1,96 @@
+import { addDays } from "../gtd/shared";
+import {
+  buildWeeklyObjectivesSnapshot,
+  type RescueTimeErrorsByObjectiveId,
+  type RescueTimeSecondsByObjectiveId
+} from "../../domain/weekly-objectives";
+import { buildWeekDates } from "../../domain/weekly-review";
+import type { RescueTimeTaxonomy, RescueTimeTaxonomyEntry, WeeklyObjectivesSnapshot } from "../../domain/types";
+import { getTodayDate } from "../date";
+import type { AppRepository } from "../storage/repository";
+import { defaultRescueTimeClient, type RescueTimeClient } from "./client";
+import { parseRankRows, resolveObjectiveSeconds } from "./parse-analytic-data";
+
+export class WeeklyObjectivesService {
+  constructor(
+    private readonly repository: AppRepository,
+    private readonly client: RescueTimeClient = defaultRescueTimeClient
+  ) {}
+
+  async computeWeeklyObjectivesSnapshot(weekStartDate: string): Promise<WeeklyObjectivesSnapshot> {
+    const normalized = buildWeekDates(weekStartDate);
+    const weekEndDate = addDays(normalized, 6);
+    const [objectives, results, settings] = await Promise.all([
+      this.repository.listWeeklyObjectives(),
+      this.repository.getWeeklyObjectiveResults(normalized),
+      this.repository.getSettings()
+    ]);
+
+    const apiKey = settings.rescuetimeApiKey.trim();
+    const rescuetimeConfigured = apiKey.length > 0;
+    const timeObjectives = objectives.filter((objective) => objective.kind === "time");
+    const secondsByObjectiveId: RescueTimeSecondsByObjectiveId = {};
+    const errorsByObjectiveId: RescueTimeErrorsByObjectiveId = {};
+    let fetchError: string | undefined;
+
+    if (timeObjectives.length > 0 && rescuetimeConfigured) {
+      const kindGroups = new Map<RescueTimeTaxonomy, typeof timeObjectives>();
+
+      for (const objective of timeObjectives) {
+        const kind = objective.rescuetimeKind ?? "category";
+        const group = kindGroups.get(kind) ?? [];
+        group.push(objective);
+        kindGroups.set(kind, group);
+      }
+
+      for (const [kind, group] of kindGroups) {
+        try {
+          const payload = await this.client.fetchAnalyticData(apiKey, {
+            kind,
+            begin: normalized,
+            end: weekEndDate
+          });
+          const rows = parseRankRows(payload);
+
+          for (const objective of group) {
+            secondsByObjectiveId[objective.id] = resolveObjectiveSeconds(rows, objective.rescuetimeThing);
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Echec de la requete RescueTime.";
+          fetchError = message;
+          for (const objective of group) {
+            errorsByObjectiveId[objective.id] = message;
+          }
+        }
+      }
+    }
+
+    return buildWeeklyObjectivesSnapshot(normalized, objectives, results, secondsByObjectiveId, {
+      rescuetimeConfigured,
+      fetchError,
+      errorsByObjectiveId
+    });
+  }
+
+  async listRescueTimeTaxonomy(
+    kind: RescueTimeTaxonomy,
+    begin: string,
+    end: string
+  ): Promise<RescueTimeTaxonomyEntry[]> {
+    const settings = await this.repository.getSettings();
+    const apiKey = settings.rescuetimeApiKey.trim();
+
+    if (!apiKey) {
+      throw new Error("Cle API RescueTime manquante.");
+    }
+
+    const payload = await this.client.fetchAnalyticData(apiKey, { kind, begin, end });
+    return parseRankRows(payload).map(({ name, seconds, hours }) => ({ name, seconds, hours }));
+  }
+
+  async testConnection(): Promise<RescueTimeTaxonomyEntry[]> {
+    const weekStart = buildWeekDates(getTodayDate());
+    const weekEnd = addDays(weekStart, 6);
+    return this.listRescueTimeTaxonomy("category", weekStart, weekEnd);
+  }
+}

--- a/src/lib/storage/memory-repository.test.ts
+++ b/src/lib/storage/memory-repository.test.ts
@@ -727,4 +727,46 @@ describe("MemoryRepository", () => {
       ])
     );
   });
+
+  it("persists weekly objectives and per-week manual results", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const saved = await repository.saveWeeklyObjective({
+      id: "",
+      title: "Software Development",
+      kind: "time",
+      targetHours: 2,
+      rescuetimeKind: "category",
+      rescuetimeThing: "Software Development",
+      sortOrder: 0,
+      createdAt: "",
+      updatedAt: ""
+    });
+
+    await repository.saveWeeklyObjectiveResult({
+      weekStartDate: "2026-08-03",
+      objectiveId: saved.id,
+      achieved: false,
+      updatedAt: ""
+    });
+
+    await expect(repository.listWeeklyObjectives()).resolves.toEqual([
+      expect.objectContaining({
+        id: saved.id,
+        title: "Software Development"
+      })
+    ]);
+
+    await expect(repository.getWeeklyObjectiveResults("2026-08-03")).resolves.toEqual([
+      expect.objectContaining({
+        objectiveId: saved.id,
+        achieved: false
+      })
+    ]);
+
+    await repository.deleteWeeklyObjective(saved.id);
+    await expect(repository.listWeeklyObjectives()).resolves.toEqual([]);
+    await expect(repository.getWeeklyObjectiveResults("2026-08-03")).resolves.toEqual([]);
+  });
 });

--- a/src/lib/storage/memory-repository.ts
+++ b/src/lib/storage/memory-repository.ts
@@ -24,6 +24,10 @@ import {
   cloneWeeklyReview,
   listWeekDates
 } from "../../domain/weekly-review";
+import {
+  cloneWeeklyObjective,
+  createEmptyWeeklyObjective
+} from "../../domain/weekly-objectives";
 import { getTodayDate } from "../date";
 import type {
   AnnualGoal,
@@ -44,6 +48,8 @@ import type {
   TaskContext,
   TaskEvent,
   TaskFilters,
+  WeeklyObjective,
+  WeeklyObjectiveResult,
   WeeklyReview
 } from "../../domain/types";
 import {
@@ -96,6 +102,8 @@ import type { AppRepository, PomodoroStartOptions } from "./repository";
 export class MemoryRepository implements AppRepository {
   private entries = new Map<string, DailyEntry>();
   private weeklyReviews = new Map<string, WeeklyReview>();
+  private weeklyObjectives = new Map<string, WeeklyObjective>();
+  private weeklyObjectiveResults = new Map<string, WeeklyObjectiveResult>();
   private monthlyReviews = new Map<string, MonthlyReview>();
   private annualGoals = new Map<string, AnnualGoal>();
   private settings: AppSettings = defaultAppSettings();
@@ -161,6 +169,53 @@ export class MemoryRepository implements AppRepository {
     );
 
     return buildWeeklyReviewSummary(normalized, entries);
+  }
+
+  async listWeeklyObjectives(): Promise<WeeklyObjective[]> {
+    return [...this.weeklyObjectives.values()]
+      .sort((left, right) => left.sortOrder - right.sortOrder || left.title.localeCompare(right.title))
+      .map((objective) => cloneWeeklyObjective(objective));
+  }
+
+  async saveWeeklyObjective(objective: WeeklyObjective): Promise<WeeklyObjective> {
+    const timestamp = nowIso();
+    const nextObjective = createEmptyWeeklyObjective({
+      ...cloneWeeklyObjective(objective),
+      id: objective.id || createEntityId("weekly-objective"),
+      title: objective.title.trim(),
+      createdAt: objective.createdAt || timestamp,
+      updatedAt: timestamp
+    });
+    this.weeklyObjectives.set(nextObjective.id, nextObjective);
+    return cloneWeeklyObjective(nextObjective);
+  }
+
+  async deleteWeeklyObjective(objectiveId: string): Promise<void> {
+    this.weeklyObjectives.delete(objectiveId);
+    for (const [key, result] of this.weeklyObjectiveResults) {
+      if (result.objectiveId === objectiveId) {
+        this.weeklyObjectiveResults.delete(key);
+      }
+    }
+  }
+
+  async getWeeklyObjectiveResults(weekStartDate: string): Promise<WeeklyObjectiveResult[]> {
+    const normalized = buildWeekDates(weekStartDate);
+    return [...this.weeklyObjectiveResults.values()]
+      .filter((result) => result.weekStartDate === normalized)
+      .map((result) => ({ ...result }));
+  }
+
+  async saveWeeklyObjectiveResult(result: WeeklyObjectiveResult): Promise<void> {
+    const normalized = buildWeekDates(result.weekStartDate);
+    const timestamp = nowIso();
+    const nextResult: WeeklyObjectiveResult = {
+      weekStartDate: normalized,
+      objectiveId: result.objectiveId,
+      achieved: result.achieved,
+      updatedAt: timestamp
+    };
+    this.weeklyObjectiveResults.set(`${normalized}:${result.objectiveId}`, nextResult);
   }
 
   async getMonthlyReview(monthKey: string): Promise<MonthlyReview | null> {

--- a/src/lib/storage/repository.ts
+++ b/src/lib/storage/repository.ts
@@ -25,7 +25,9 @@ import type {
   AnnualGoal,
   AnnualGoalSnapshot,
   WeeklyReview,
-  WeeklyReviewSummary
+  WeeklyReviewSummary,
+  WeeklyObjective,
+  WeeklyObjectiveResult
 } from "../../domain/types";
 
 export interface StorageInfo {
@@ -61,6 +63,11 @@ export interface AppRepository {
   saveWeeklyReview(review: WeeklyReview): Promise<void>;
   listWeeklyReviews(limit?: number): Promise<WeeklyReview[]>;
   computeWeeklyReviewSummary(weekStartDate: string): Promise<WeeklyReviewSummary>;
+  listWeeklyObjectives(): Promise<WeeklyObjective[]>;
+  saveWeeklyObjective(objective: WeeklyObjective): Promise<WeeklyObjective>;
+  deleteWeeklyObjective(objectiveId: string): Promise<void>;
+  getWeeklyObjectiveResults(weekStartDate: string): Promise<WeeklyObjectiveResult[]>;
+  saveWeeklyObjectiveResult(result: WeeklyObjectiveResult): Promise<void>;
   getMonthlyReview(monthKey: string): Promise<MonthlyReview | null>;
   saveMonthlyReview(review: MonthlyReview): Promise<void>;
   listMonthlyReviews(limit?: number): Promise<MonthlyReview[]>;

--- a/src/lib/storage/tauri-sqlite-repository.ts
+++ b/src/lib/storage/tauri-sqlite-repository.ts
@@ -37,8 +37,14 @@ import type {
   Task,
   TaskContext,
   TaskEvent,
+  WeeklyObjective,
+  WeeklyObjectiveResult,
   WeeklyReview
 } from "../../domain/types";
+import {
+  cloneWeeklyObjective,
+  createEmptyWeeklyObjective
+} from "../../domain/weekly-objectives";
 import {
   buildDailyTaskBreakdown,
   buildCarryoverEvents,
@@ -112,6 +118,25 @@ interface WeeklyReviewRow {
   status: WeeklyReview["status"];
   notes_json: string;
   ritual_checklist_json: string;
+  updated_at: string;
+}
+
+interface WeeklyObjectiveRow {
+  id: string;
+  title: string;
+  kind: WeeklyObjective["kind"];
+  target_hours: number | null;
+  rescuetime_kind: WeeklyObjective["rescuetimeKind"];
+  rescuetime_thing: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WeeklyObjectiveResultRow {
+  week_start_date: string;
+  objective_id: string;
+  achieved: number;
   updated_at: string;
 }
 
@@ -500,6 +525,32 @@ const migrations: Migration[] = [
     sql: `
       ALTER TABLE pomodoro_sessions ADD COLUMN paused_remaining_ms INTEGER;
     `
+  },
+  {
+    id: 20,
+    name: "create_weekly_objectives",
+    sql: `
+      CREATE TABLE IF NOT EXISTS weekly_objectives (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        target_hours REAL,
+        rescuetime_kind TEXT,
+        rescuetime_thing TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS weekly_objective_results (
+        week_start_date TEXT NOT NULL,
+        objective_id TEXT NOT NULL,
+        achieved INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (week_start_date, objective_id),
+        FOREIGN KEY (objective_id) REFERENCES weekly_objectives(id) ON DELETE CASCADE
+      );
+    `
   }
 ];
 
@@ -865,6 +916,97 @@ export class TauriSqliteRepository implements AppRepository {
     );
 
     return buildWeeklyReviewSummary(normalized, entries);
+  }
+
+  async listWeeklyObjectives(): Promise<WeeklyObjective[]> {
+    const db = await this.getDb();
+    const rows = await db.select<WeeklyObjectiveRow[]>(
+      `SELECT
+        id, title, kind, target_hours, rescuetime_kind, rescuetime_thing, sort_order, created_at, updated_at
+      FROM weekly_objectives
+      ORDER BY sort_order ASC, title ASC`
+    );
+
+    return rows.map((row) => this.deserializeWeeklyObjective(row));
+  }
+
+  async saveWeeklyObjective(objective: WeeklyObjective): Promise<WeeklyObjective> {
+    const db = await this.getDb();
+    const timestamp = nowIso();
+    const nextObjective = createEmptyWeeklyObjective({
+      ...cloneWeeklyObjective(objective),
+      id: objective.id || createEntityId("weekly-objective"),
+      title: objective.title.trim(),
+      createdAt: objective.createdAt || timestamp,
+      updatedAt: timestamp
+    });
+
+    await db.execute(
+      `INSERT INTO weekly_objectives (
+        id, title, kind, target_hours, rescuetime_kind, rescuetime_thing, sort_order, created_at, updated_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      ON CONFLICT(id) DO UPDATE SET
+        title = excluded.title,
+        kind = excluded.kind,
+        target_hours = excluded.target_hours,
+        rescuetime_kind = excluded.rescuetime_kind,
+        rescuetime_thing = excluded.rescuetime_thing,
+        sort_order = excluded.sort_order,
+        updated_at = excluded.updated_at`,
+      [
+        nextObjective.id,
+        nextObjective.title,
+        nextObjective.kind,
+        nextObjective.targetHours,
+        nextObjective.rescuetimeKind,
+        nextObjective.rescuetimeThing,
+        nextObjective.sortOrder,
+        nextObjective.createdAt,
+        nextObjective.updatedAt
+      ]
+    );
+
+    return cloneWeeklyObjective(nextObjective);
+  }
+
+  async deleteWeeklyObjective(objectiveId: string): Promise<void> {
+    const db = await this.getDb();
+    await db.execute("DELETE FROM weekly_objective_results WHERE objective_id = $1", [objectiveId]);
+    await db.execute("DELETE FROM weekly_objectives WHERE id = $1", [objectiveId]);
+  }
+
+  async getWeeklyObjectiveResults(weekStartDate: string): Promise<WeeklyObjectiveResult[]> {
+    const db = await this.getDb();
+    const normalized = buildWeekDates(weekStartDate);
+    const rows = await db.select<WeeklyObjectiveResultRow[]>(
+      `SELECT week_start_date, objective_id, achieved, updated_at
+       FROM weekly_objective_results
+       WHERE week_start_date = $1`,
+      [normalized]
+    );
+
+    return rows.map((row) => this.deserializeWeeklyObjectiveResult(row));
+  }
+
+  async saveWeeklyObjectiveResult(result: WeeklyObjectiveResult): Promise<void> {
+    const db = await this.getDb();
+    const normalized = buildWeekDates(result.weekStartDate);
+    const timestamp = nowIso();
+    const nextResult: WeeklyObjectiveResult = {
+      weekStartDate: normalized,
+      objectiveId: result.objectiveId,
+      achieved: result.achieved,
+      updatedAt: timestamp
+    };
+
+    await db.execute(
+      `INSERT INTO weekly_objective_results (week_start_date, objective_id, achieved, updated_at)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT(week_start_date, objective_id) DO UPDATE SET
+         achieved = excluded.achieved,
+         updated_at = excluded.updated_at`,
+      [nextResult.weekStartDate, nextResult.objectiveId, nextResult.achieved ? 1 : 0, nextResult.updatedAt]
+    );
   }
 
   async getSettings(): Promise<AppSettings> {
@@ -1741,6 +1883,29 @@ export class TauriSqliteRepository implements AppRepository {
       status: row.status,
       notes: JSON.parse(row.notes_json),
       ritualChecklist: JSON.parse(row.ritual_checklist_json),
+      updatedAt: row.updated_at
+    };
+  }
+
+  private deserializeWeeklyObjective(row: WeeklyObjectiveRow): WeeklyObjective {
+    return {
+      id: row.id,
+      title: row.title,
+      kind: row.kind,
+      targetHours: row.target_hours === null ? null : Number(row.target_hours),
+      rescuetimeKind: row.rescuetime_kind,
+      rescuetimeThing: row.rescuetime_thing,
+      sortOrder: Number(row.sort_order),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+  }
+
+  private deserializeWeeklyObjectiveResult(row: WeeklyObjectiveResultRow): WeeklyObjectiveResult {
+    return {
+      weekStartDate: row.week_start_date,
+      objectiveId: row.objective_id,
+      achieved: row.achieved === 1,
       updatedAt: row.updated_at
     };
   }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -225,11 +225,10 @@ export const SettingsPage = () => {
                 setRescuetimeMessage("");
 
                 try {
-                  await saveSettings(draftSettings);
                   const result = await goalsService.testConnection(draftSettings.rescuetimeApiKey);
                   setRescuetimeMessage(
                     result.goalCount > 0
-                      ? `Connexion OK. ${result.goalCount} goal(s) actif(s). Exemple: ${result.sampleGoal}.`
+                      ? `Connexion OK. ${result.goalCount} goal(s) actif(s). Exemple: ${result.sampleGoal}. Enregistre la cle pour l'utiliser dans l'app.`
                       : "Connexion OK, mais aucun goal RescueTime actif trouve."
                   );
                 } catch (error) {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { defaultAppSettings } from "../domain/daily-entry";
 import type { AppSettings } from "../domain/types";
 import { useAppContext } from "../app/app-context";
@@ -6,11 +6,16 @@ import { SectionCard } from "../components/SectionCard";
 import initialGoogleTasksExport from "../../Tasks.json";
 import { formatDateTimeShort } from "../lib/date";
 import type { StorageInfo } from "../lib/storage/repository";
+import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
 
 export const SettingsPage = () => {
   const { repository, settings, saveSettings, debugEnabled, setDebugEnabled, browserPreview } = useAppContext();
+  const goalsService = useMemo(() => new RescueTimeGoalsService(repository), [repository]);
   const [draftSettings, setDraftSettings] = useState<AppSettings>(settings);
   const [savingSettings, setSavingSettings] = useState(false);
+  const [savingRescuetimeSettings, setSavingRescuetimeSettings] = useState(false);
+  const [rescuetimeMessage, setRescuetimeMessage] = useState("");
+  const [testingRescuetime, setTestingRescuetime] = useState(false);
   const [savingBackupSettings, setSavingBackupSettings] = useState(false);
   const [importingGtd, setImportingGtd] = useState(false);
   const [gtdMessage, setGtdMessage] = useState("");
@@ -164,6 +169,77 @@ export const SettingsPage = () => {
               onClick={() => setDraftSettings(defaultAppSettings())}
             >
               Reinitialiser
+            </button>
+          </div>
+        </form>
+      </SectionCard>
+
+      <SectionCard
+        title="RescueTime"
+        subtitle="Cle API stockee localement dans SQLite. Utilise-la pour charger tes goals RescueTime dans la revue hebdomadaire — modifiable a tout moment, y compris dans l'app bundlee."
+      >
+        {rescuetimeMessage ? <div className="banner">{rescuetimeMessage}</div> : null}
+
+        <form
+          className="settings-form"
+          onSubmit={async (event) => {
+            event.preventDefault();
+            setSavingRescuetimeSettings(true);
+            setRescuetimeMessage("");
+
+            try {
+              await saveSettings(draftSettings);
+              setRescuetimeMessage("Cle RescueTime enregistree.");
+            } catch (error) {
+              setRescuetimeMessage(error instanceof Error ? error.message : "Echec de l'enregistrement RescueTime.");
+            } finally {
+              setSavingRescuetimeSettings(false);
+            }
+          }}
+        >
+          <label>
+            <span>Cle API RescueTime</span>
+            <input
+              type="password"
+              value={draftSettings.rescuetimeApiKey}
+              onChange={(event) =>
+                setDraftSettings((current) => ({
+                  ...current,
+                  rescuetimeApiKey: event.target.value
+                }))
+              }
+              placeholder="Bearer token RescueTime"
+            />
+          </label>
+
+          <div className="form-actions">
+            <button className="button button--primary" type="submit" disabled={savingRescuetimeSettings}>
+              {savingRescuetimeSettings ? "Enregistrement..." : "Enregistrer la cle RescueTime"}
+            </button>
+            <button
+              className="button"
+              type="button"
+              disabled={testingRescuetime || !draftSettings.rescuetimeApiKey.trim()}
+              onClick={async () => {
+                setTestingRescuetime(true);
+                setRescuetimeMessage("");
+
+                try {
+                  await saveSettings(draftSettings);
+                  const result = await goalsService.testConnection(draftSettings.rescuetimeApiKey);
+                  setRescuetimeMessage(
+                    result.goalCount > 0
+                      ? `Connexion OK. ${result.goalCount} goal(s) actif(s). Exemple: ${result.sampleGoal}.`
+                      : "Connexion OK, mais aucun goal RescueTime actif trouve."
+                  );
+                } catch (error) {
+                  setRescuetimeMessage(error instanceof Error ? error.message : "Echec du test RescueTime.");
+                } finally {
+                  setTestingRescuetime(false);
+                }
+              }}
+            >
+              {testingRescuetime ? "Test en cours..." : "Tester la connexion"}
             </button>
           </div>
         </form>

--- a/src/pages/WeeklyReviewPage.test.tsx
+++ b/src/pages/WeeklyReviewPage.test.tsx
@@ -6,6 +6,12 @@ import { renderWithApp } from "../test/test-utils";
 import { WeeklyReviewPage } from "./WeeklyReviewPage";
 
 describe("WeeklyReviewPage", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
   it("loads a week summary and saves ritual notes and checklist", async () => {
     const repository = new MemoryRepository();
     await repository.initialize();
@@ -56,6 +62,59 @@ describe("WeeklyReviewPage", () => {
           bilan: "Semaine solide."
         })
       });
+    });
+  });
+
+  it("renders RescueTime goals score", async () => {
+    globalThis.fetch = vi.fn(async (input) => {
+      const url = String(input);
+
+      if (url.includes("/api/resource/goals")) {
+        return Response.json([
+          {
+            id: 1,
+            display_name: "more than 2h on Personal (24x7)",
+            amount_seconds: 7200,
+            is_more: true,
+            enabled: true,
+            taxon_id: 15,
+            taxonomy_name: "overview",
+            schedule_name: "24x7",
+            overview: { name: "Personal" }
+          }
+        ]);
+      }
+
+      if (url.includes("restrict_kind=overview")) {
+        return Response.json({
+          row_headers: ["Rank", "Time Spent (seconds)", "Category"],
+          rows: [[1, 12600, "Personal"]]
+        });
+      }
+
+      return Response.json({ project_times: [] });
+    }) as typeof fetch;
+
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
+    });
+
+    const user = userEvent.setup();
+    await renderWithApp(<WeeklyReviewPage />, { repository, route: "/semaine" });
+
+    const dateInput = await screen.findByLabelText(/debut de semaine/i);
+    await user.clear(dateInput);
+    await user.type(dateInput, "2026-08-02");
+    await user.click(screen.getByRole("button", { name: /charger la semaine/i }));
+
+    expect(await screen.findByText("Objectifs de la semaine")).toBeInTheDocument();
+    expect(await screen.findByText("more than 2h on Personal (24x7)")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("0.25/1")).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/WeeklyReviewPage.test.tsx
+++ b/src/pages/WeeklyReviewPage.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createEmptyDailyEntry } from "../domain/daily-entry";
 import { MemoryRepository } from "../lib/storage/memory-repository";
+import { formatPercent } from "../lib/format";
 import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
 import { renderWithApp } from "../test/test-utils";
 import { WeeklyReviewPage } from "./WeeklyReviewPage";
@@ -87,6 +88,12 @@ describe("WeeklyReviewPage", () => {
     };
 
     vi.spyOn(RescueTimeGoalsService.prototype, "computeGoalsSnapshot").mockResolvedValue(goalsSnapshot);
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeProductivityPulse").mockResolvedValue({
+      weekStartDate: "2026-08-02",
+      weekEndDate: "2026-08-08",
+      pulse: null,
+      rescuetimeConfigured: true
+    });
 
     const repository = new MemoryRepository();
     await repository.initialize();
@@ -118,5 +125,77 @@ describe("WeeklyReviewPage", () => {
       expect(screen.getByText("more than 2h on Personal (24x7)")).toBeInTheDocument();
       expect(screen.getByText("0.25/1")).toBeInTheDocument();
     });
+  });
+
+  it("overlays RescueTime axes into the weekly score when snapshots match the week", async () => {
+    const weekStart = "2026-08-02";
+    const goalsSnapshot = {
+      weekStartDate: weekStart,
+      weekEndDate: "2026-08-08",
+      score: 1,
+      totalAchievement: 1,
+      items: [],
+      rescuetimeConfigured: true
+    };
+    const pulseSnapshot = {
+      weekStartDate: weekStart,
+      weekEndDate: "2026-08-08",
+      pulse: 100,
+      rescuetimeConfigured: true
+    };
+
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeGoalsSnapshot").mockResolvedValue(goalsSnapshot);
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeProductivityPulse").mockResolvedValue(pulseSnapshot);
+
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const weekDates = [
+      weekStart,
+      "2026-08-03",
+      "2026-08-04",
+      "2026-08-05",
+      "2026-08-06",
+      "2026-08-07",
+      "2026-08-08"
+    ];
+
+    for (const date of weekDates) {
+      const entry = createEmptyDailyEntry(date);
+      entry.metrics.qualiteSommeil = 80;
+      entry.principleChecks.priereDuMatin = true;
+      await repository.saveDailyEntry(entry);
+    }
+
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
+    });
+
+    const user = userEvent.setup();
+    await renderWithApp(<WeeklyReviewPage />, {
+      repository,
+      route: "/semaine",
+      contextOverrides: {
+        settings: {
+          ...(await repository.getSettings()),
+          rescuetimeApiKey: "rt-test-key"
+        }
+      }
+    });
+
+    const dateInput = await screen.findByLabelText(/debut de semaine/i);
+    await user.clear(dateInput);
+    await user.type(dateInput, weekStart);
+    await user.click(screen.getByRole("button", { name: /charger la semaine/i }));
+
+    const localSummary = await repository.computeWeeklyReviewSummary(weekStart);
+
+    await waitFor(() => {
+      const scoreCard = screen.getAllByText("Score hebdo")[0].closest("article");
+      expect(scoreCard?.querySelector("strong")?.textContent).not.toBe(formatPercent(localSummary.weeklyScore));
+    });
+
+    expect(localSummary.weeklyScore).toBeLessThan(0.5);
   });
 });

--- a/src/pages/WeeklyReviewPage.test.tsx
+++ b/src/pages/WeeklyReviewPage.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createEmptyDailyEntry } from "../domain/daily-entry";
 import { MemoryRepository } from "../lib/storage/memory-repository";
+import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
 import { renderWithApp } from "../test/test-utils";
 import { WeeklyReviewPage } from "./WeeklyReviewPage";
 
@@ -66,34 +67,26 @@ describe("WeeklyReviewPage", () => {
   });
 
   it("renders RescueTime goals score", async () => {
-    globalThis.fetch = vi.fn(async (input) => {
-      const url = String(input);
+    const goalsSnapshot = {
+      weekStartDate: "2026-08-02",
+      weekEndDate: "2026-08-08",
+      score: 0.25,
+      totalAchievement: 0.25,
+      items: [
+        {
+          goalId: 1,
+          title: "more than 2h on Personal (24x7)",
+          isMore: true,
+          actualHours: 3.5,
+          weeklyTargetHours: 14,
+          achievement: 0.25,
+          scheduleLabel: "24x7"
+        }
+      ],
+      rescuetimeConfigured: true
+    };
 
-      if (url.includes("/api/resource/goals")) {
-        return Response.json([
-          {
-            id: 1,
-            display_name: "more than 2h on Personal (24x7)",
-            amount_seconds: 7200,
-            is_more: true,
-            enabled: true,
-            taxon_id: 15,
-            taxonomy_name: "overview",
-            schedule_name: "24x7",
-            overview: { name: "Personal" }
-          }
-        ]);
-      }
-
-      if (url.includes("restrict_kind=overview")) {
-        return Response.json({
-          row_headers: ["Rank", "Time Spent (seconds)", "Category"],
-          rows: [[1, 12600, "Personal"]]
-        });
-      }
-
-      return Response.json({ project_times: [] });
-    }) as typeof fetch;
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeGoalsSnapshot").mockResolvedValue(goalsSnapshot);
 
     const repository = new MemoryRepository();
     await repository.initialize();
@@ -103,7 +96,16 @@ describe("WeeklyReviewPage", () => {
     });
 
     const user = userEvent.setup();
-    await renderWithApp(<WeeklyReviewPage />, { repository, route: "/semaine" });
+    await renderWithApp(<WeeklyReviewPage />, {
+      repository,
+      route: "/semaine",
+      contextOverrides: {
+        settings: {
+          ...(await repository.getSettings()),
+          rescuetimeApiKey: "rt-test-key"
+        }
+      }
+    });
 
     const dateInput = await screen.findByLabelText(/debut de semaine/i);
     await user.clear(dateInput);
@@ -111,9 +113,9 @@ describe("WeeklyReviewPage", () => {
     await user.click(screen.getByRole("button", { name: /charger la semaine/i }));
 
     expect(await screen.findByText("Objectifs de la semaine")).toBeInTheDocument();
-    expect(await screen.findByText("more than 2h on Personal (24x7)")).toBeInTheDocument();
 
     await waitFor(() => {
+      expect(screen.getByText("more than 2h on Personal (24x7)")).toBeInTheDocument();
       expect(screen.getByText("0.25/1")).toBeInTheDocument();
     });
   });

--- a/src/pages/WeeklyReviewPage.tsx
+++ b/src/pages/WeeklyReviewPage.tsx
@@ -115,29 +115,48 @@ export const WeeklyReviewPage = () => {
   const [goalsMessage, setGoalsMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const latestReviewRef = useRef<WeeklyReview | null>(null);
+  const goalsRequestSeqRef = useRef(0);
 
   const loadGoalsSnapshot = useCallback(
     async (requestedWeekStart: string) => {
+      const requestId = ++goalsRequestSeqRef.current;
       setGoalsLoading(true);
       setGoalsMessage("");
-      const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
-      setGoalsSnapshot(snapshot);
-      setGoalsLoading(false);
+      try {
+        const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
+        if (requestId !== goalsRequestSeqRef.current) {
+          return;
+        }
+        setGoalsSnapshot(snapshot);
+      } finally {
+        if (requestId === goalsRequestSeqRef.current) {
+          setGoalsLoading(false);
+        }
+      }
     },
     [goalsService]
   );
 
   const refreshGoalsSnapshot = useCallback(
     async (requestedWeekStart: string) => {
+      const requestId = ++goalsRequestSeqRef.current;
       setGoalsRefreshing(true);
       setGoalsMessage("");
       try {
         const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
+        if (requestId !== goalsRequestSeqRef.current) {
+          return;
+        }
         setGoalsSnapshot(snapshot);
       } catch (error) {
+        if (requestId !== goalsRequestSeqRef.current) {
+          return;
+        }
         setGoalsMessage(error instanceof Error ? error.message : "Echec du rafraichissement RescueTime.");
       } finally {
-        setGoalsRefreshing(false);
+        if (requestId === goalsRequestSeqRef.current) {
+          setGoalsRefreshing(false);
+        }
       }
     },
     [goalsService]
@@ -362,7 +381,7 @@ export const WeeklyReviewPage = () => {
             className="button"
             type="button"
             disabled={goalsRefreshing || goalsLoading || !settings.rescuetimeApiKey.trim()}
-            onClick={() => void refreshGoalsSnapshot(selectedWeekStart)}
+            onClick={() => void refreshGoalsSnapshot(summary.weekStartDate)}
           >
             {goalsRefreshing ? "Rafraichissement..." : "Rafraichir RescueTime Goals"}
           </button>

--- a/src/pages/WeeklyReviewPage.tsx
+++ b/src/pages/WeeklyReviewPage.tsx
@@ -4,6 +4,7 @@ import { useAppContext } from "../app/app-context";
 import { deriveStatusLabel } from "../domain/daily-entry";
 import {
   applyWeeklyReviewTransition,
+  applyWeeklyScoreExternalAxes,
   buildWeekDates,
   createEmptyWeeklyReview,
   updateWeeklyReviewChecklist,
@@ -20,7 +21,7 @@ import { SectionCard } from "../components/SectionCard";
 import { formatDateLong, formatDateShort, getTodayDate } from "../lib/date";
 import { formatPercent, formatTimestamp } from "../lib/format";
 import { addDays } from "../lib/gtd/shared";
-import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
+import { RescueTimeGoalsService, type RescueTimeProductivityPulseSnapshot } from "../lib/rescuetime/rescuetime-goals-service";
 
 interface RitualSectionDefinition {
   key: WeeklyRitualSectionKey;
@@ -100,6 +101,9 @@ const formatHours = (hours: number | null): string =>
 const formatObjectiveScore = (score: number | null): string =>
   score === null ? "—" : formatPercent(score);
 
+const formatPulse = (value: number | null): string =>
+  value === null ? "—" : `${Math.round(value)} / 100`;
+
 const deriveWeeklyStatusLabel = (status: WeeklyReview["status"]): string =>
   status === "closed" ? "Revue cloturee" : "Brouillon";
 
@@ -110,53 +114,64 @@ export const WeeklyReviewPage = () => {
   const [review, setReview] = useState<WeeklyReview | null>(null);
   const [summary, setSummary] = useState<WeeklyReviewSummary | null>(null);
   const [goalsSnapshot, setGoalsSnapshot] = useState<RescueTimeGoalsSnapshot | null>(null);
-  const [goalsLoading, setGoalsLoading] = useState(true);
-  const [goalsRefreshing, setGoalsRefreshing] = useState(false);
-  const [goalsMessage, setGoalsMessage] = useState("");
+  const [pulseSnapshot, setPulseSnapshot] = useState<RescueTimeProductivityPulseSnapshot | null>(null);
+  const [rescueTimeLoading, setRescueTimeLoading] = useState(true);
+  const [rescueTimeRefreshing, setRescueTimeRefreshing] = useState(false);
+  const [rescueTimeMessage, setRescueTimeMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const latestReviewRef = useRef<WeeklyReview | null>(null);
   const weekRequestSeqRef = useRef(0);
-  const goalsRequestSeqRef = useRef(0);
+  const rescueTimeRequestSeqRef = useRef(0);
 
-  const loadGoalsSnapshot = useCallback(
+  const loadRescueTimeData = useCallback(
     async (requestedWeekStart: string) => {
-      const requestId = ++goalsRequestSeqRef.current;
-      setGoalsLoading(true);
-      setGoalsMessage("");
+      const requestId = ++rescueTimeRequestSeqRef.current;
+      setRescueTimeLoading(true);
+      setRescueTimeMessage("");
       try {
-        const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
-        if (requestId !== goalsRequestSeqRef.current) {
+        const [goals, pulse] = await Promise.all([
+          goalsService.computeGoalsSnapshot(requestedWeekStart),
+          goalsService.computeProductivityPulse(requestedWeekStart)
+        ]);
+        if (requestId !== rescueTimeRequestSeqRef.current) {
           return;
         }
-        setGoalsSnapshot(snapshot);
+        setGoalsSnapshot(goals);
+        setPulseSnapshot(pulse);
       } finally {
-        if (requestId === goalsRequestSeqRef.current) {
-          setGoalsLoading(false);
+        if (requestId === rescueTimeRequestSeqRef.current) {
+          setRescueTimeLoading(false);
         }
       }
     },
     [goalsService]
   );
 
-  const refreshGoalsSnapshot = useCallback(
+  const refreshRescueTimeData = useCallback(
     async (requestedWeekStart: string) => {
-      const requestId = ++goalsRequestSeqRef.current;
-      setGoalsRefreshing(true);
-      setGoalsMessage("");
+      const requestId = ++rescueTimeRequestSeqRef.current;
+      setRescueTimeRefreshing(true);
+      setRescueTimeMessage("");
       try {
-        const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
-        if (requestId !== goalsRequestSeqRef.current) {
+        const [goals, pulse] = await Promise.all([
+          goalsService.computeGoalsSnapshot(requestedWeekStart),
+          goalsService.computeProductivityPulse(requestedWeekStart)
+        ]);
+        if (requestId !== rescueTimeRequestSeqRef.current) {
           return;
         }
-        setGoalsSnapshot(snapshot);
+        setGoalsSnapshot(goals);
+        setPulseSnapshot(pulse);
       } catch (error) {
-        if (requestId !== goalsRequestSeqRef.current) {
+        if (requestId !== rescueTimeRequestSeqRef.current) {
           return;
         }
-        setGoalsMessage(error instanceof Error ? error.message : "Echec du rafraichissement RescueTime.");
+        setRescueTimeMessage(
+          error instanceof Error ? error.message : "Echec du rafraichissement RescueTime."
+        );
       } finally {
-        if (requestId === goalsRequestSeqRef.current) {
-          setGoalsRefreshing(false);
+        if (requestId === rescueTimeRequestSeqRef.current) {
+          setRescueTimeRefreshing(false);
         }
       }
     },
@@ -181,14 +196,14 @@ export const WeeklyReviewPage = () => {
         setSelectedWeekStart(normalized);
         setReview(nextReview);
         setSummary(computedSummary);
-        void loadGoalsSnapshot(normalized);
+        void loadRescueTimeData(normalized);
       } finally {
         if (requestId === weekRequestSeqRef.current) {
           setLoading(false);
         }
       }
     },
-    [loadGoalsSnapshot, repository]
+    [loadRescueTimeData, repository]
   );
 
   useEffect(() => {
@@ -223,11 +238,27 @@ export const WeeklyReviewPage = () => {
     previousRescuetimeApiKeyRef.current = settings.rescuetimeApiKey;
 
     if (hasValidSelectedWeek) {
-      void loadGoalsSnapshot(selectedWeekStart);
+      void loadRescueTimeData(selectedWeekStart);
     }
-  }, [settings.rescuetimeApiKey, hasValidSelectedWeek, loadGoalsSnapshot, selectedWeekStart]);
+  }, [settings.rescuetimeApiKey, hasValidSelectedWeek, loadRescueTimeData, selectedWeekStart]);
 
-  if (loading || !review || !summary) {
+  const displayedSummary = useMemo(() => {
+    if (!summary) {
+      return null;
+    }
+
+    const rescueTimeGoalsScore =
+      goalsSnapshot?.weekStartDate === summary.weekStartDate ? goalsSnapshot.score : null;
+    const productivityPulse =
+      pulseSnapshot?.weekStartDate === summary.weekStartDate ? pulseSnapshot.pulse : null;
+
+    return applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore,
+      productivityPulse
+    });
+  }, [goalsSnapshot, pulseSnapshot, summary]);
+
+  if (loading || !review || !summary || !displayedSummary) {
     return <div className="page"><p>Chargement de la revue hebdomadaire...</p></div>;
   }
 
@@ -321,7 +352,7 @@ export const WeeklyReviewPage = () => {
           </article>
           <article className="status-card">
             <span>Score hebdo</span>
-            <strong>{formatPercent(summary.weeklyScore)}</strong>
+            <strong>{formatPercent(displayedSummary.weeklyScore)}</strong>
           </article>
           <article className="status-card">
             <span>Sommeil moyen</span>
@@ -340,6 +371,16 @@ export const WeeklyReviewPage = () => {
             <strong>{summary.pomodorisTotal}</strong>
           </article>
           <article className="status-card">
+            <span>Depense calorique moyenne</span>
+            <strong>{Math.round(summary.calorieAverage)} kcal</strong>
+          </article>
+          <article className="status-card">
+            <span>Productivite ordinateur</span>
+            <strong>
+              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
+            </strong>
+          </article>
+          <article className="status-card">
             <span>Discipline moyenne</span>
             <strong>{formatWholePercent(summary.disciplineAverage * 100)}</strong>
           </article>
@@ -356,7 +397,7 @@ export const WeeklyReviewPage = () => {
         title="Objectifs de la semaine"
         subtitle="Score base sur tes RescueTime Goals: chaque objectif vaut au plus 1 point, avec scoring fractionnel sur le temps."
       >
-        {goalsMessage ? <div className="banner">{goalsMessage}</div> : null}
+        {rescueTimeMessage ? <div className="banner">{rescueTimeMessage}</div> : null}
         {!settings.rescuetimeApiKey.trim() ? (
           <div className="banner">
             Cle RescueTime manquante. Configure-la dans{" "}
@@ -364,20 +405,27 @@ export const WeeklyReviewPage = () => {
           </div>
         ) : null}
         {goalsSnapshot?.fetchError ? <div className="banner">{goalsSnapshot.fetchError}</div> : null}
+        {pulseSnapshot?.fetchError ? <div className="banner">{pulseSnapshot.fetchError}</div> : null}
 
         <div className="weekly-overview-grid">
           <article className="status-card">
             <span>Score objectifs</span>
-            <strong>{goalsLoading || !goalsSnapshot ? "..." : formatObjectiveScore(goalsSnapshot.score)}</strong>
+            <strong>{rescueTimeLoading || !goalsSnapshot ? "..." : formatObjectiveScore(goalsSnapshot.score)}</strong>
           </article>
           <article className="status-card">
             <span>Points obtenus</span>
             <strong>
-              {goalsLoading || !goalsSnapshot
+              {rescueTimeLoading || !goalsSnapshot
                 ? "..."
                 : goalsSnapshot.items.length === 0
                   ? "—"
                   : `${goalsSnapshot.totalAchievement.toFixed(2)} / ${goalsSnapshot.items.length}`}
+            </strong>
+          </article>
+          <article className="status-card">
+            <span>Productivite ordinateur</span>
+            <strong>
+              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
             </strong>
           </article>
           <article className="status-card">
@@ -390,14 +438,14 @@ export const WeeklyReviewPage = () => {
           <button
             className="button"
             type="button"
-            disabled={goalsRefreshing || goalsLoading || !settings.rescuetimeApiKey.trim()}
-            onClick={() => void refreshGoalsSnapshot(summary.weekStartDate)}
+            disabled={rescueTimeRefreshing || rescueTimeLoading || !settings.rescuetimeApiKey.trim()}
+            onClick={() => void refreshRescueTimeData(summary.weekStartDate)}
           >
-            {goalsRefreshing ? "Rafraichissement..." : "Rafraichir RescueTime Goals"}
+            {rescueTimeRefreshing ? "Rafraichissement..." : "Rafraichir RescueTime"}
           </button>
         </div>
 
-        {goalsLoading || !goalsSnapshot ? (
+        {rescueTimeLoading || !goalsSnapshot ? (
           <p className="empty-copy">Chargement des objectifs RescueTime...</p>
         ) : goalsSnapshot.fetchError ? null : goalsSnapshot.items.length === 0 ? (
           <p className="empty-copy">Aucun goal RescueTime actif trouve pour ce compte.</p>
@@ -437,8 +485,12 @@ export const WeeklyReviewPage = () => {
             <strong>{formatWholePercent(summary.phoneScreenTime)}</strong>
           </article>
           <article className="status-card">
-            <span>Score pomodoris</span>
+            <span>Score temps focus</span>
             <strong>{formatWholePercent(summary.pomodoris)}</strong>
+          </article>
+          <article className="status-card">
+            <span>Activite physique</span>
+            <strong>{formatWholePercent(summary.physicalActivity)}</strong>
           </article>
           <article className="status-card">
             <span>Score discipline</span>
@@ -447,6 +499,18 @@ export const WeeklyReviewPage = () => {
           <article className="status-card">
             <span>Taux de completion</span>
             <strong>{formatWholePercent(summary.tasksCompletionRate)}</strong>
+          </article>
+          <article className="status-card">
+            <span>Productivite ordinateur</span>
+            <strong>
+              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
+            </strong>
+          </article>
+          <article className="status-card">
+            <span>Score objectifs RescueTime</span>
+            <strong>
+              {rescueTimeLoading || !goalsSnapshot ? "..." : formatObjectiveScore(displayedSummary.rescueTimeGoalsScore)}
+            </strong>
           </article>
         </div>
       </SectionCard>
@@ -464,6 +528,7 @@ export const WeeklyReviewPage = () => {
                 <span>TRC: {day.trcRespected ? "Oui" : "Non"}</span>
                 <span>Ecran: {day.screenTimeMinutes} min</span>
                 <span>Pomodoris: {day.pomodoris}</span>
+                <span>Kcal: {day.calorieExpenditure}</span>
                 <span>Discipline: {formatWholePercent(day.disciplineScore * 100)}</span>
                 <span>
                   Taches: {day.tasksCompleted}/{day.tasksAdded}

--- a/src/pages/WeeklyReviewPage.tsx
+++ b/src/pages/WeeklyReviewPage.tsx
@@ -115,6 +115,7 @@ export const WeeklyReviewPage = () => {
   const [goalsMessage, setGoalsMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const latestReviewRef = useRef<WeeklyReview | null>(null);
+  const weekRequestSeqRef = useRef(0);
   const goalsRequestSeqRef = useRef(0);
 
   const loadGoalsSnapshot = useCallback(
@@ -164,19 +165,28 @@ export const WeeklyReviewPage = () => {
 
   const loadWeek = useCallback(
     async (requestedWeekStart: string) => {
+      const requestId = ++weekRequestSeqRef.current;
       const normalized = buildWeekDates(requestedWeekStart);
       setLoading(true);
-      const [existingReview, computedSummary] = await Promise.all([
-        repository.getWeeklyReview(normalized),
-        repository.computeWeeklyReviewSummary(normalized)
-      ]);
-      const nextReview = existingReview ?? createEmptyWeeklyReview(normalized);
-      latestReviewRef.current = nextReview;
-      setSelectedWeekStart(normalized);
-      setReview(nextReview);
-      setSummary(computedSummary);
-      setLoading(false);
-      void loadGoalsSnapshot(normalized);
+      try {
+        const [existingReview, computedSummary] = await Promise.all([
+          repository.getWeeklyReview(normalized),
+          repository.computeWeeklyReviewSummary(normalized)
+        ]);
+        if (requestId !== weekRequestSeqRef.current) {
+          return;
+        }
+        const nextReview = existingReview ?? createEmptyWeeklyReview(normalized);
+        latestReviewRef.current = nextReview;
+        setSelectedWeekStart(normalized);
+        setReview(nextReview);
+        setSummary(computedSummary);
+        void loadGoalsSnapshot(normalized);
+      } finally {
+        if (requestId === weekRequestSeqRef.current) {
+          setLoading(false);
+        }
+      }
     },
     [loadGoalsSnapshot, repository]
   );
@@ -389,7 +399,7 @@ export const WeeklyReviewPage = () => {
 
         {goalsLoading || !goalsSnapshot ? (
           <p className="empty-copy">Chargement des objectifs RescueTime...</p>
-        ) : goalsSnapshot.items.length === 0 ? (
+        ) : goalsSnapshot.fetchError ? null : goalsSnapshot.items.length === 0 ? (
           <p className="empty-copy">Aucun goal RescueTime actif trouve pour ce compte.</p>
         ) : (
           <div className="weekly-day-grid">

--- a/src/pages/WeeklyReviewPage.tsx
+++ b/src/pages/WeeklyReviewPage.tsx
@@ -9,12 +9,18 @@ import {
   updateWeeklyReviewChecklist,
   updateWeeklyReviewNote
 } from "../domain/weekly-review";
-import type { WeeklyReview, WeeklyReviewSummary, WeeklyRitualSectionKey } from "../domain/types";
+import type {
+  WeeklyReview,
+  WeeklyReviewSummary,
+  WeeklyRitualSectionKey
+} from "../domain/types";
+import type { RescueTimeGoalsSnapshot } from "../domain/rescuetime-goals";
 import { PersistedTextarea } from "../components/PersistedTextarea";
 import { SectionCard } from "../components/SectionCard";
 import { formatDateLong, formatDateShort, getTodayDate } from "../lib/date";
 import { formatPercent, formatTimestamp } from "../lib/format";
 import { addDays } from "../lib/gtd/shared";
+import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
 
 interface RitualSectionDefinition {
   key: WeeklyRitualSectionKey;
@@ -88,16 +94,54 @@ const ritualSections: RitualSectionDefinition[] = [
 
 const formatWholePercent = (value: number): string => `${Math.round(value)}%`;
 
+const formatHours = (hours: number | null): string =>
+  hours === null ? "—" : `${hours.toFixed(2)} h`;
+
+const formatObjectiveScore = (score: number | null): string =>
+  score === null ? "—" : formatPercent(score);
+
 const deriveWeeklyStatusLabel = (status: WeeklyReview["status"]): string =>
   status === "closed" ? "Revue cloturee" : "Brouillon";
 
 export const WeeklyReviewPage = () => {
-  const { repository } = useAppContext();
+  const { repository, settings } = useAppContext();
+  const goalsService = useMemo(() => new RescueTimeGoalsService(repository), [repository]);
   const [selectedWeekStart, setSelectedWeekStart] = useState(buildWeekDates(getTodayDate()));
   const [review, setReview] = useState<WeeklyReview | null>(null);
   const [summary, setSummary] = useState<WeeklyReviewSummary | null>(null);
+  const [goalsSnapshot, setGoalsSnapshot] = useState<RescueTimeGoalsSnapshot | null>(null);
+  const [goalsLoading, setGoalsLoading] = useState(true);
+  const [goalsRefreshing, setGoalsRefreshing] = useState(false);
+  const [goalsMessage, setGoalsMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const latestReviewRef = useRef<WeeklyReview | null>(null);
+
+  const loadGoalsSnapshot = useCallback(
+    async (requestedWeekStart: string) => {
+      setGoalsLoading(true);
+      setGoalsMessage("");
+      const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
+      setGoalsSnapshot(snapshot);
+      setGoalsLoading(false);
+    },
+    [goalsService]
+  );
+
+  const refreshGoalsSnapshot = useCallback(
+    async (requestedWeekStart: string) => {
+      setGoalsRefreshing(true);
+      setGoalsMessage("");
+      try {
+        const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
+        setGoalsSnapshot(snapshot);
+      } catch (error) {
+        setGoalsMessage(error instanceof Error ? error.message : "Echec du rafraichissement RescueTime.");
+      } finally {
+        setGoalsRefreshing(false);
+      }
+    },
+    [goalsService]
+  );
 
   const loadWeek = useCallback(
     async (requestedWeekStart: string) => {
@@ -113,8 +157,9 @@ export const WeeklyReviewPage = () => {
       setReview(nextReview);
       setSummary(computedSummary);
       setLoading(false);
+      void loadGoalsSnapshot(normalized);
     },
-    [repository]
+    [loadGoalsSnapshot, repository]
   );
 
   useEffect(() => {
@@ -138,6 +183,20 @@ export const WeeklyReviewPage = () => {
     () => (hasValidSelectedWeek ? addDays(selectedWeekStart, 6) : ""),
     [hasValidSelectedWeek, selectedWeekStart]
   );
+
+  const previousRescuetimeApiKeyRef = useRef(settings.rescuetimeApiKey);
+
+  useEffect(() => {
+    if (previousRescuetimeApiKeyRef.current === settings.rescuetimeApiKey) {
+      return;
+    }
+
+    previousRescuetimeApiKeyRef.current = settings.rescuetimeApiKey;
+
+    if (hasValidSelectedWeek) {
+      void loadGoalsSnapshot(selectedWeekStart);
+    }
+  }, [settings.rescuetimeApiKey, hasValidSelectedWeek, loadGoalsSnapshot, selectedWeekStart]);
 
   if (loading || !review || !summary) {
     return <div className="page"><p>Chargement de la revue hebdomadaire...</p></div>;
@@ -262,6 +321,76 @@ export const WeeklyReviewPage = () => {
             </strong>
           </article>
         </div>
+      </SectionCard>
+
+      <SectionCard
+        title="Objectifs de la semaine"
+        subtitle="Score base sur tes RescueTime Goals: chaque objectif vaut au plus 1 point, avec scoring fractionnel sur le temps."
+      >
+        {goalsMessage ? <div className="banner">{goalsMessage}</div> : null}
+        {!settings.rescuetimeApiKey.trim() ? (
+          <div className="banner">
+            Cle RescueTime manquante. Configure-la dans{" "}
+            <Link to="/parametres">Parametres</Link> pour charger tes goals RescueTime.
+          </div>
+        ) : null}
+        {goalsSnapshot?.fetchError ? <div className="banner">{goalsSnapshot.fetchError}</div> : null}
+
+        <div className="weekly-overview-grid">
+          <article className="status-card">
+            <span>Score objectifs</span>
+            <strong>{goalsLoading || !goalsSnapshot ? "..." : formatObjectiveScore(goalsSnapshot.score)}</strong>
+          </article>
+          <article className="status-card">
+            <span>Points obtenus</span>
+            <strong>
+              {goalsLoading || !goalsSnapshot
+                ? "..."
+                : goalsSnapshot.items.length === 0
+                  ? "—"
+                  : `${goalsSnapshot.totalAchievement.toFixed(2)} / ${goalsSnapshot.items.length}`}
+            </strong>
+          </article>
+          <article className="status-card">
+            <span>Source</span>
+            <strong>{settings.rescuetimeApiKey.trim() ? "RescueTime Goals" : "Cle manquante"}</strong>
+          </article>
+        </div>
+
+        <div className="form-actions">
+          <button
+            className="button"
+            type="button"
+            disabled={goalsRefreshing || goalsLoading || !settings.rescuetimeApiKey.trim()}
+            onClick={() => void refreshGoalsSnapshot(selectedWeekStart)}
+          >
+            {goalsRefreshing ? "Rafraichissement..." : "Rafraichir RescueTime Goals"}
+          </button>
+        </div>
+
+        {goalsLoading || !goalsSnapshot ? (
+          <p className="empty-copy">Chargement des objectifs RescueTime...</p>
+        ) : goalsSnapshot.items.length === 0 ? (
+          <p className="empty-copy">Aucun goal RescueTime actif trouve pour ce compte.</p>
+        ) : (
+          <div className="weekly-day-grid">
+            {goalsSnapshot.items.map((item) => (
+              <article key={item.goalId} className="schedule-day-group">
+                <div className="schedule-day-group__header">
+                  <h3>{item.title}</h3>
+                  <span>{item.achievement.toFixed(2)}/1</span>
+                </div>
+                <div className="weekly-day-card__metrics">
+                  <span>{item.isMore ? "Plus de temps" : "Moins de temps"}</span>
+                  <span>
+                    Temps: {formatHours(item.actualHours)} / {formatHours(item.weeklyTargetHours)} (cible hebdo)
+                  </span>
+                  <span>Horaire: {item.scheduleLabel}</span>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
       </SectionCard>
 
       <SectionCard title="Axes automatiques" subtitle="Scores derives des metriques quotidiennes de la semaine.">


### PR DESCRIPTION
## Summary
- Expand Score hebdo on `/semaine` to nine axes: physical activity (`depenseCalorique` vs 3800 kcal/day avg), sleep, TRC, phone screen, task completion, discipline, RescueTime Goals, computer productivity pulse, and focused time (Pomodoro).
- Fetch Sunday–Saturday RescueTime productivity pulse via Analytic Data (`restrict_kind=productivity`) and fold Goals + pulse into the weekly score only when non-null and week-matched; monthly/annual stay on the local 7-axis mean.
- Update weekly review UI, domain tests, and docs for the new formula and API usage.

## Review process
- Went through `plan-review` first (1 iteration → approved).
- Went through `develop-review` (first-pass approval, 0 fix cycles).

## Test plan
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] On `/semaine` with RescueTime key: Score hebdo updates after Goals + pulse load; calorie average and pulse shown
- [ ] Without RescueTime key: Score hebdo stays 7-axis local; pulse/goals show `—`
- [ ] Switch weeks: previous week’s RescueTime values do not affect the new week’s score until matching snapshots arrive
- [ ] `/mois` / annual weekly score pick up calories but not RescueTime overlays


Made with [Cursor](https://cursor.com)