### PR TITLE
Fold calories and RescueTime pulse into weekly score

### DIFF
--- a/docs/ai-settings-and-privacy.md
+++ b/docs/ai-settings-and-privacy.md
@@ -122,8 +122,9 @@ Authorization: Bearer {rescuetimeApiKey}
 ```
 
 The weekly review also fetches a **productivity pulse** with
-`restrict_kind=productivity` and no `restrict_schedule_id` (full-week computer
-time, Sunday–Saturday).
+`restrict_kind=productivity`, `restrict_source_type=computers`, and no
+`restrict_schedule_id` (full-week computer time only, Sunday–Saturday). Browser and
+native RescueTime requests use a 20-second abortable timeout.
 
 The key is stored locally in the singleton `app_settings` row, merged with defaults
 on read, and included in SQLite backups. It is never logged by the app. You can

--- a/docs/ai-settings-and-privacy.md
+++ b/docs/ai-settings-and-privacy.md
@@ -121,6 +121,10 @@ GET https://www.rescuetime.com/anapi/data
 Authorization: Bearer {rescuetimeApiKey}
 ```
 
+The weekly review also fetches a **productivity pulse** with
+`restrict_kind=productivity` and no `restrict_schedule_id` (full-week computer
+time, Sunday–Saturday).
+
 The key is stored locally in the singleton `app_settings` row, merged with defaults
 on read, and included in SQLite backups. It is never logged by the app. You can
 change it at any time while the app is running; the weekly review reloads goals

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,7 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-08-12 | Weekly score: seven local axes (calories at 3800 kcal/day), optional RescueTime Goals + productivity pulse overlay on `/semaine` | `docs/reviews-and-goals.md`, `docs/ai-settings-and-privacy.md` | `src/domain/weekly-review.ts`, `src/lib/rescuetime/rescuetime-goals-service.ts`, weekly review page |
 | 2026-08-12 | Retry Pomodoro history/summary snapshots after a transient list-read failure so the page cannot stay on pre-action history after the active session already updated | `docs/recurrences-and-pomodoro.md` | `src/app/use-pomodoro-controller.ts`, Pomodoro controller tests |
 | 2026-08-11 | Documented RescueTime dual transport (Tauri native HTTP vs browser fetch fallback) | `docs/ai-settings-and-privacy.md` | `fetchRescueTimeJson`, `rescuetime_http_get` |
 | 2026-08-11 | Clarified RescueTime API key is app settings only at runtime; Settings test uses Goals API; weekly review reloads on key change | `docs/ai-settings-and-privacy.md`, `docs/reviews-and-goals.md` | Settings page, `RescueTimeGoalsService.testConnection`, weekly review effect |

--- a/docs/reviews-and-goals.md
+++ b/docs/reviews-and-goals.md
@@ -53,6 +53,7 @@ Each day contributes:
 - whether TRC is exactly `true`;
 - phone screen minutes;
 - Pomodoro count;
+- calorie expenditure;
 - discipline fraction;
 - tasks added;
 - tasks completed.
@@ -70,27 +71,43 @@ Explicit daily metrics override suggested GTD/Pomodoro values.
 | Discipline | Average of seven daily discipline fractions |
 | Tasks added/completed | Sum of daily values |
 | Task completion rate | Completed / added; zero when added is zero |
+| Calorie average | Mean of seven daily values (null → 0) |
+| Physical activity axis | `(calorieAverage * 100) / 3800`, lower-clamped |
 
-The automatic score has six axes:
+The automatic score has **seven local axes** (used by monthly and annual summaries):
 
 1. Sleep quality against 100.
 2. TRC percentage against 100.
 3. Phone screen axis, where 840 weekly minutes is 100, zero minutes is 200, and
    1,680 minutes is zero (lower-clamped, not upper-clamped).
-4. Pomodoro axis, where 56 weekly sessions is 100.
+4. Focus time (Pomodoro) axis, where 56 weekly sessions is 100.
 5. Discipline percentage against 100.
 6. Task completion percentage against 100.
+7. Physical activity axis against 3,800 kcal/day average.
 
 Each axis is passed through `scoreAgainstTarget(value, 100)`. Values through the
 target scale linearly from zero to one; above-target performance continues at half
-the rate. `weeklyScore` is the mean of those six normalized axis values and can
-therefore exceed `1` (100%).
+the rate. Repository `weeklyScore` is the mean of those seven normalized axis values
+and can therefore exceed `1` (100%).
+
+On `/semaine`, two optional **RescueTime axes** overlay the score when data is
+available (non-null):
+
+8. RescueTime Goals score (`0–1` from enabled goals).
+9. Computer productivity pulse (`0–100`, time-weighted from Analytic Data).
+
+`applyWeeklyScoreExternalAxes()` recomputes the displayed weekly score as the mean
+of the seven local axes plus each non-null RescueTime axis. Stale RescueTime
+snapshots from a different week are ignored until the matching week loads. Monthly
+`weeklyScoreAverage` and annual `weekly_weekly_score` use the seven-axis local score
+only (calories included; RescueTime excluded).
 
 ### Weekly objectives (RescueTime Goals)
 
-The `/semaine` screen loads **enabled RescueTime Goals** from the Resource API and
-scores them for the selected Sunday–Saturday week. This score is separate from the
-six-axis `weeklyScore` above.
+The `/semaine` screen loads **enabled RescueTime Goals** and a **productivity pulse**
+from the Analytic Data API for the selected Sunday–Saturday week. These scores feed
+the optional RescueTime axes above; they are not persisted and are not part of the
+repository weekly summary.
 
 Each goal is worth at most **1 point**:
 
@@ -108,6 +125,26 @@ score = sum(achievement) / count(goals)
 ```
 
 When there are no enabled goals, the score displays `—` (null), not `0%`.
+
+### Computer productivity pulse
+
+The weekly pulse uses Analytic Data with `restrict_kind=productivity` (no
+`restrict_schedule_id`):
+
+```text
+GET anapi/data?format=json&perspective=rank&restrict_kind=productivity
+  &restrict_begin={Sunday}&restrict_end={Saturday}
+```
+
+RescueTime productivity levels (`-2`..`+2`) are time-weighted:
+
+```text
+mean = sum(productivityLevel * seconds) / sum(seconds)
+pulse = ((mean + 2) / 4) * 100
+```
+
+When there is no tracked computer time (`sum(seconds) === 0`), the pulse is `null`
+and excluded from the displayed weekly score. A real `0` pulse is included.
 
 Goals are read-only in TrackDidia — manage them in RescueTime. Configure the API key
 under **Parametres → RescueTime** (stored in SQLite, same as OpenRouter). Time data

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -47,7 +47,10 @@ fn resolve_storage_paths(app: tauri::AppHandle) -> Result<StoragePaths, String> 
 
 #[tauri::command]
 async fn rescuetime_http_get(url: String, api_key: String) -> Result<String, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .map_err(|error| format!("RescueTime HTTP client failed: {error}"))?;
     let response = client
         .get(&url)
         .header("Authorization", format!("Bearer {api_key}"))

--- a/src/domain/annual-goals.test.ts
+++ b/src/domain/annual-goals.test.ts
@@ -45,6 +45,10 @@ describe("annual goals domain", () => {
         tasksAddedTotal: 0,
         tasksCompletedTotal: 0,
         tasksCompletionRate: 0,
+        calorieAverage: 0,
+        physicalActivity: 0,
+        productivityPulse: null,
+        rescueTimeGoalsScore: null,
         weeklyScore: 0.5,
         days: []
       },
@@ -64,6 +68,10 @@ describe("annual goals domain", () => {
         tasksAddedTotal: 0,
         tasksCompletedTotal: 0,
         tasksCompletionRate: 0,
+        calorieAverage: 0,
+        physicalActivity: 0,
+        productivityPulse: null,
+        rescueTimeGoalsScore: null,
         weeklyScore: 0.55,
         days: []
       }

--- a/src/domain/annual-goals.ts
+++ b/src/domain/annual-goals.ts
@@ -74,7 +74,15 @@ const sourceDefinitions: AnnualGoalSourceDefinition[] = [
     label: "Score hebdo moyen",
     type: "weekly_summary",
     weeklyMetricLabels: ["Score hebdo"],
-    dailyHabitLabels: ["Sommeil", "TRC", "Temps d'ecran", "Pomodoris", "Discipline", "Taches"],
+    dailyHabitLabels: [
+      "Sommeil",
+      "TRC",
+      "Temps d'ecran",
+      "Temps focus",
+      "Discipline",
+      "Taches",
+      "Depense calorique"
+    ],
     computeCurrent: (_entries, weeklySummaries) => {
       const value = weeklyAverage(weeklySummaries, (summary) => summary.weeklyScore);
       return value === null ? null : value * 100;

--- a/src/domain/monthly-review.test.ts
+++ b/src/domain/monthly-review.test.ts
@@ -62,6 +62,10 @@ describe("monthly review domain", () => {
         tasksAddedTotal: 16,
         tasksCompletedTotal: 12,
         tasksCompletionRate: 75,
+        calorieAverage: 0,
+        physicalActivity: 0,
+        productivityPulse: null,
+        rescueTimeGoalsScore: null,
         weeklyScore: 0.6,
         days: []
       }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -76,6 +76,7 @@ export interface WeeklyReviewDaySummary {
   trcRespected: boolean;
   screenTimeMinutes: number;
   pomodoris: number;
+  calorieExpenditure: number;
   disciplineScore: number;
   tasksAdded: number;
   tasksCompleted: number;
@@ -97,6 +98,10 @@ export interface WeeklyReviewSummary {
   tasksAddedTotal: number;
   tasksCompletedTotal: number;
   tasksCompletionRate: number;
+  calorieAverage: number;
+  physicalActivity: number;
+  productivityPulse: number | null;
+  rescueTimeGoalsScore: number | null;
   weeklyScore: number;
   days: WeeklyReviewDaySummary[];
 }

--- a/src/domain/weekly-review.test.ts
+++ b/src/domain/weekly-review.test.ts
@@ -5,7 +5,14 @@ import {
   updateMetric,
   updatePrinciple
 } from "./daily-entry";
-import { buildWeeklyReviewSummary, createEmptyWeeklyReview, updateWeeklyReviewChecklist, updateWeeklyReviewNote } from "./weekly-review";
+import {
+  applyWeeklyScoreExternalAxes,
+  buildWeeklyReviewSummary,
+  createEmptyWeeklyReview,
+  localWeeklyScoreAxes,
+  updateWeeklyReviewChecklist,
+  updateWeeklyReviewNote
+} from "./weekly-review";
 
 describe("weekly review domain", () => {
   it("builds weekly aggregates from seven daily entries", () => {
@@ -56,6 +63,10 @@ describe("weekly review domain", () => {
     expect(summary.tasksCompletedTotal).toBe(21);
     expect(summary.tasksCompletionRate).toBeCloseTo(75);
     expect(summary.disciplineAverage).toBeGreaterThan(0);
+    expect(summary.calorieAverage).toBe(0);
+    expect(summary.physicalActivity).toBe(0);
+    expect(summary.productivityPulse).toBeNull();
+    expect(summary.rescueTimeGoalsScore).toBeNull();
     expect(summary.weeklyScore).toBeGreaterThan(0);
     expect(summary.days).toHaveLength(7);
   });
@@ -120,5 +131,80 @@ describe("weekly review domain", () => {
     expect(review.notes.bilan).toBe("");
     expect(withNote.notes.bilan).toBe("Semaine dense.");
     expect(withCheck.ritualChecklist.dimanche).toBe(true);
+  });
+
+  it("includes calorie expenditure in weekly and daily summaries", () => {
+    const weekDates = [
+      "2026-03-29",
+      "2026-03-30",
+      "2026-03-31",
+      "2026-04-01",
+      "2026-04-02",
+      "2026-04-03",
+      "2026-04-04"
+    ];
+
+    const entries = weekDates.map((date, index) => {
+      let entry = createEmptyDailyEntry(date);
+      entry = updateMetric(entry, "depenseCalorique", 3800 + index * 100);
+      return entry;
+    });
+
+    const summary = buildWeeklyReviewSummary("2026-03-29", entries);
+
+    expect(summary.calorieAverage).toBeCloseTo(4100);
+    expect(summary.physicalActivity).toBeCloseTo((4100 * 100) / 3800);
+    expect(summary.days.every((day) => day.calorieExpenditure > 0)).toBe(true);
+  });
+
+  it("recomputes weekly score with RescueTime axes when provided", () => {
+    const summary = buildWeeklyReviewSummary("2026-03-29", [
+      createEmptyDailyEntry("2026-03-29"),
+      createEmptyDailyEntry("2026-03-30"),
+      createEmptyDailyEntry("2026-03-31"),
+      createEmptyDailyEntry("2026-04-01"),
+      createEmptyDailyEntry("2026-04-02"),
+      createEmptyDailyEntry("2026-04-03"),
+      createEmptyDailyEntry("2026-04-04")
+    ]);
+
+    const localScore = summary.weeklyScore;
+    const withRescueTime = applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore: 0.5,
+      productivityPulse: 80
+    });
+
+    expect(withRescueTime.rescueTimeGoalsScore).toBe(0.5);
+    expect(withRescueTime.productivityPulse).toBe(80);
+    expect(withRescueTime.weeklyScore).toBeGreaterThan(localScore);
+    expect(localWeeklyScoreAxes(withRescueTime)).toHaveLength(7);
+  });
+
+  it("ignores RescueTime fields already on summary when computing local axes", () => {
+    const summary = applyWeeklyScoreExternalAxes(
+      buildWeeklyReviewSummary("2026-03-29", [
+        createEmptyDailyEntry("2026-03-29"),
+        createEmptyDailyEntry("2026-03-30"),
+        createEmptyDailyEntry("2026-03-31"),
+        createEmptyDailyEntry("2026-04-01"),
+        createEmptyDailyEntry("2026-04-02"),
+        createEmptyDailyEntry("2026-04-03"),
+        createEmptyDailyEntry("2026-04-04")
+      ]),
+      {
+        rescueTimeGoalsScore: 1,
+        productivityPulse: 100
+      }
+    );
+
+    const reapplied = applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore: null,
+      productivityPulse: null
+    });
+
+    expect(reapplied.rescueTimeGoalsScore).toBeNull();
+    expect(reapplied.productivityPulse).toBeNull();
+    expect(reapplied.weeklyScore).toBeLessThan(summary.weeklyScore);
+    expect(localWeeklyScoreAxes(summary)).toEqual(localWeeklyScoreAxes(reapplied));
   });
 });

--- a/src/domain/weekly-review.test.ts
+++ b/src/domain/weekly-review.test.ts
@@ -168,16 +168,39 @@ describe("weekly review domain", () => {
       createEmptyDailyEntry("2026-04-04")
     ]);
 
-    const localScore = summary.weeklyScore;
-    const withRescueTime = applyWeeklyScoreExternalAxes(summary, {
+    const localAxes = localWeeklyScoreAxes(summary);
+    const withBoth = applyWeeklyScoreExternalAxes(summary, {
       rescueTimeGoalsScore: 0.5,
       productivityPulse: 80
     });
+    const withGoalsOnly = applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore: 0.5,
+      productivityPulse: null
+    });
+    const withPulseOnly = applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore: null,
+      productivityPulse: 80
+    });
+    const withGoalsZero = applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore: 0,
+      productivityPulse: null
+    });
 
-    expect(withRescueTime.rescueTimeGoalsScore).toBe(0.5);
-    expect(withRescueTime.productivityPulse).toBe(80);
-    expect(withRescueTime.weeklyScore).toBeGreaterThan(localScore);
-    expect(localWeeklyScoreAxes(withRescueTime)).toHaveLength(7);
+    expect(localAxes).toHaveLength(7);
+    expect(withBoth.weeklyScore).toBeCloseTo(
+      (localAxes.reduce((sum, value) => sum + value, 0) + 0.5 + 0.8) / 9
+    );
+    expect(withGoalsOnly.weeklyScore).toBeCloseTo(
+      (localAxes.reduce((sum, value) => sum + value, 0) + 0.5) / 8
+    );
+    expect(withPulseOnly.weeklyScore).toBeCloseTo(
+      (localAxes.reduce((sum, value) => sum + value, 0) + 0.8) / 8
+    );
+    expect(withGoalsZero.weeklyScore).toBeCloseTo(
+      (localAxes.reduce((sum, value) => sum + value, 0) + 0) / 8
+    );
+    expect(withBoth.rescueTimeGoalsScore).toBe(0.5);
+    expect(withBoth.productivityPulse).toBe(80);
   });
 
   it("ignores RescueTime fields already on summary when computing local axes", () => {

--- a/src/domain/weekly-review.ts
+++ b/src/domain/weekly-review.ts
@@ -13,6 +13,7 @@ import type {
 
 const phoneScreenTargetMinutes = 840;
 const pomodoroTarget = 56;
+const calorieTargetDaily = 3800;
 
 const emptyWeeklyNotes = (): WeeklyReviewNotes => ({
   bilan: "",
@@ -59,6 +60,9 @@ const toPhoneScreenAxisValue = (totalMinutes: number): number =>
 
 const toPomodoroAxisValue = (pomodorisTotal: number): number =>
   pomodoroTarget > 0 ? clampAtZero((pomodorisTotal * 100) / pomodoroTarget) : 0;
+
+const toPhysicalActivityAxisValue = (calorieAverage: number): number =>
+  calorieTargetDaily > 0 ? clampAtZero((calorieAverage * 100) / calorieTargetDaily) : 0;
 
 export const buildWeekDates = (weekStartDate: string): string => {
   const normalized = getWeekStartSunday(weekStartDate);
@@ -131,10 +135,46 @@ const buildDaySummary = (entry: DailyEntry): WeeklyReviewDaySummary => ({
   trcRespected: entry.principleChecks.respectTrc === true,
   screenTimeMinutes: resolveMetricValue(entry, "tempsEcranTelephone") ?? 0,
   pomodoris: resolveMetricValue(entry, "pomodoris") ?? 0,
+  calorieExpenditure: resolveMetricValue(entry, "depenseCalorique") ?? 0,
   disciplineScore: computeDisciplineScore(entry),
   tasksAdded: resolveMetricValue(entry, "tachesAjoutes") ?? 0,
   tasksCompleted: resolveMetricValue(entry, "tachesRealises") ?? 0
 });
+
+export const localWeeklyScoreAxes = (summary: WeeklyReviewSummary): number[] => [
+  scoreAgainstTarget(summary.sleepQuality, 100),
+  scoreAgainstTarget(summary.respectTrc, 100),
+  scoreAgainstTarget(summary.phoneScreenTime, 100),
+  scoreAgainstTarget(summary.pomodoris, 100),
+  scoreAgainstTarget(summary.discipline, 100),
+  scoreAgainstTarget(summary.tasksCompletionRate, 100),
+  scoreAgainstTarget(summary.physicalActivity, 100)
+];
+
+export const applyWeeklyScoreExternalAxes = (
+  summary: WeeklyReviewSummary,
+  external: {
+    rescueTimeGoalsScore: number | null;
+    productivityPulse: number | null;
+  }
+): WeeklyReviewSummary => {
+  const axisScores = [...localWeeklyScoreAxes(summary)];
+
+  if (external.rescueTimeGoalsScore !== null) {
+    axisScores.push(scoreAgainstTarget(external.rescueTimeGoalsScore * 100, 100));
+  }
+
+  if (external.productivityPulse !== null) {
+    axisScores.push(scoreAgainstTarget(external.productivityPulse, 100));
+  }
+
+  return {
+    ...summary,
+    rescueTimeGoalsScore: external.rescueTimeGoalsScore,
+    productivityPulse: external.productivityPulse,
+    weeklyScore: average(axisScores)
+  };
+};
 
 export const buildWeeklyReviewSummary = (
   weekStartDate: string,
@@ -150,6 +190,7 @@ export const buildWeeklyReviewSummary = (
   const trcDaysRespected = daySummaries.filter((day) => day.trcRespected).length;
   const screenTimeTotalMinutes = daySummaries.reduce((sum, day) => sum + day.screenTimeMinutes, 0);
   const pomodorisTotal = daySummaries.reduce((sum, day) => sum + day.pomodoris, 0);
+  const calorieAverage = average(daySummaries.map((day) => day.calorieExpenditure));
   const disciplineAverage = average(daySummaries.map((day) => day.disciplineScore));
   const tasksAddedTotal = daySummaries.reduce((sum, day) => sum + day.tasksAdded, 0);
   const tasksCompletedTotal = daySummaries.reduce((sum, day) => sum + day.tasksCompleted, 0);
@@ -157,19 +198,12 @@ export const buildWeeklyReviewSummary = (
   const respectTrc = (trcDaysRespected / 7) * 100;
   const phoneScreenTime = toPhoneScreenAxisValue(screenTimeTotalMinutes);
   const pomodoris = toPomodoroAxisValue(pomodorisTotal);
+  const physicalActivity = toPhysicalActivityAxisValue(calorieAverage);
   const discipline = disciplineAverage * 100;
   const tasksCompletionRate =
     tasksAddedTotal > 0 ? (tasksCompletedTotal / tasksAddedTotal) * 100 : 0;
-  const weeklyScore = average([
-    scoreAgainstTarget(sleepQuality, 100),
-    scoreAgainstTarget(respectTrc, 100),
-    scoreAgainstTarget(phoneScreenTime, 100),
-    scoreAgainstTarget(pomodoris, 100),
-    scoreAgainstTarget(discipline, 100),
-    scoreAgainstTarget(tasksCompletionRate, 100)
-  ]);
 
-  return {
+  const baseSummary: WeeklyReviewSummary = {
     weekStartDate: normalized,
     weekEndDate: addDays(normalized, 6),
     sleepAverage,
@@ -185,7 +219,16 @@ export const buildWeeklyReviewSummary = (
     tasksAddedTotal,
     tasksCompletedTotal,
     tasksCompletionRate,
-    weeklyScore,
+    calorieAverage,
+    physicalActivity,
+    productivityPulse: null,
+    rescueTimeGoalsScore: null,
+    weeklyScore: 0,
     days: daySummaries
+  };
+
+  return {
+    ...baseSummary,
+    weeklyScore: average(localWeeklyScoreAxes(baseSummary))
   };
 };

--- a/src/lib/rescuetime/goals-client.test.ts
+++ b/src/lib/rescuetime/goals-client.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { RescueTimeGoalRecord } from "../../domain/rescuetime-goals";
-import { matchRankRowSeconds } from "./goals-client";
+import { HttpRescueTimeGoalsClient, matchRankRowSeconds } from "./goals-client";
+import * as httpTransport from "./http-transport";
 
 const overviewGoal = (name: string): RescueTimeGoalRecord => ({
   id: 1,
@@ -40,5 +41,33 @@ describe("matchRankRowSeconds", () => {
       { name: "Dev Tools", seconds: 150, hours: 150 / 3600 }
     ];
     expect(matchRankRowSeconds(partialRows, overviewGoal("Dev Tool"), "overview")).toBe(150);
+  });
+});
+
+describe("HttpRescueTimeGoalsClient.fetchAnalyticData", () => {
+  it("serializes restrict_source_type when sourceType is set", async () => {
+    const fetchSpy = vi.spyOn(httpTransport, "fetchRescueTimeJson").mockResolvedValue({
+      row_headers: [],
+      rows: []
+    });
+
+    const client = new HttpRescueTimeGoalsClient();
+    await client.fetchAnalyticData("rt-test-key", {
+      kind: "productivity",
+      begin: "2026-08-02",
+      end: "2026-08-08",
+      sourceType: "computers"
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const requestedUrl = String(fetchSpy.mock.calls[0]?.[0] ?? "");
+    const parsed = new URL(requestedUrl);
+    expect(parsed.searchParams.get("restrict_kind")).toBe("productivity");
+    expect(parsed.searchParams.get("restrict_begin")).toBe("2026-08-02");
+    expect(parsed.searchParams.get("restrict_end")).toBe("2026-08-08");
+    expect(parsed.searchParams.get("restrict_source_type")).toBe("computers");
+    expect(parsed.searchParams.get("restrict_schedule_id")).toBeNull();
+
+    fetchSpy.mockRestore();
   });
 });

--- a/src/lib/rescuetime/goals-client.ts
+++ b/src/lib/rescuetime/goals-client.ts
@@ -25,6 +25,7 @@ export interface RescueTimeAnalyticQuery {
   begin: string;
   end: string;
   scheduleId?: number;
+  sourceType?: string;
 }
 
 export interface RescueTimeGoalsClient {
@@ -56,6 +57,9 @@ export class HttpRescueTimeGoalsClient implements RescueTimeGoalsClient {
     url.searchParams.set("restrict_end", query.end);
     if (query.scheduleId !== undefined && query.scheduleId > 0) {
       url.searchParams.set("restrict_schedule_id", String(query.scheduleId));
+    }
+    if (query.sourceType) {
+      url.searchParams.set("restrict_source_type", query.sourceType);
     }
     return fetchRescueTimeJson<RescueTimeAnalyticPayload>(url.toString(), apiKey);
   }

--- a/src/lib/rescuetime/http-transport.ts
+++ b/src/lib/rescuetime/http-transport.ts
@@ -1,22 +1,66 @@
 import { invoke } from "@tauri-apps/api/core";
 import { isTauriRuntime } from "../storage/factory";
 
-export const fetchRescueTimeJson = async <T>(url: string, apiKey: string): Promise<T> => {
-  if (isTauriRuntime()) {
-    const body = await invoke<string>("rescuetime_http_get", { url, apiKey });
-    return JSON.parse(body) as T;
-  }
+export const RESCUETIME_REQUEST_TIMEOUT_MS = 20_000;
 
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${apiKey}`
+const createTimeoutController = (timeoutMs: number): { signal: AbortSignal; clear: () => void } => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    clear: () => {
+      clearTimeout(timeoutId);
     }
-  });
+  };
+};
 
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throw new Error(`RescueTime API ${response.status}: ${errorBody.slice(0, 200)}`);
+const toTimeoutError = (error: unknown): Error => {
+  if (error instanceof Error && (error.name === "AbortError" || /aborted|timed out/i.test(error.message))) {
+    return new Error("RescueTime request timed out.");
   }
+  return error instanceof Error ? error : new Error("RescueTime request failed.");
+};
 
-  return response.json() as Promise<T>;
+export const fetchRescueTimeJson = async <T>(url: string, apiKey: string): Promise<T> => {
+  const timeout = createTimeoutController(RESCUETIME_REQUEST_TIMEOUT_MS);
+
+  try {
+    if (isTauriRuntime()) {
+      const body = await Promise.race([
+        invoke<string>("rescuetime_http_get", { url, apiKey }),
+        new Promise<never>((_, reject) => {
+          const onAbort = () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          };
+          if (timeout.signal.aborted) {
+            onAbort();
+            return;
+          }
+          timeout.signal.addEventListener("abort", onAbort, { once: true });
+        })
+      ]);
+      return JSON.parse(body) as T;
+    }
+
+    const response = await fetch(url, {
+      signal: timeout.signal,
+      headers: {
+        Authorization: `Bearer ${apiKey}`
+      }
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`RescueTime API ${response.status}: ${errorBody.slice(0, 200)}`);
+    }
+
+    return response.json() as Promise<T>;
+  } catch (error) {
+    throw toTimeoutError(error);
+  } finally {
+    timeout.clear();
+  }
 };

--- a/src/lib/rescuetime/productivity-mapping.test.ts
+++ b/src/lib/rescuetime/productivity-mapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { productivitySecondsForGoal } from "./productivity-mapping";
+import { computeProductivityPulse, productivitySecondsForGoal } from "./productivity-mapping";
 
 describe("productivitySecondsForGoal", () => {
   const rows = [
@@ -47,5 +47,36 @@ describe("productivitySecondsForGoal", () => {
         productivity: { id: 2, name: "very productive", display_name: "Focus Work" }
       })
     ).toBe(3600);
+  });
+});
+
+describe("computeProductivityPulse", () => {
+  it("returns a time-weighted pulse on a 0-100 scale", () => {
+    expect(
+      computeProductivityPulse([
+        { productivity: 2, seconds: 3600 },
+        { productivity: 0, seconds: 3600 }
+      ])
+    ).toBe(75);
+  });
+
+  it("returns null when no tracked seconds remain", () => {
+    expect(computeProductivityPulse([])).toBeNull();
+    expect(computeProductivityPulse([{ productivity: 1, seconds: 0 }])).toBeNull();
+  });
+
+  it("skips rows with non-finite values", () => {
+    expect(
+      computeProductivityPulse([
+        { productivity: Number.NaN, seconds: 3600 },
+        { productivity: 2, seconds: Number.POSITIVE_INFINITY },
+        { productivity: 1, seconds: 1800 }
+      ])
+    ).toBe(75);
+  });
+
+  it("clamps pulse to 0-100", () => {
+    expect(computeProductivityPulse([{ productivity: 2, seconds: 3600 }])).toBe(100);
+    expect(computeProductivityPulse([{ productivity: -2, seconds: 3600 }])).toBe(0);
   });
 });

--- a/src/lib/rescuetime/productivity-mapping.ts
+++ b/src/lib/rescuetime/productivity-mapping.ts
@@ -77,3 +77,25 @@ export const productivitySecondsForGoal = (
     .filter((row) => row.productivity === productivityId)
     .reduce((sum, row) => sum + row.seconds, 0);
 };
+
+export const computeProductivityPulse = (rows: ParsedProductivityRow[]): number | null => {
+  let weightedSum = 0;
+  let totalSeconds = 0;
+
+  for (const row of rows) {
+    if (!Number.isFinite(row.seconds) || !Number.isFinite(row.productivity)) {
+      continue;
+    }
+
+    weightedSum += row.productivity * row.seconds;
+    totalSeconds += row.seconds;
+  }
+
+  if (totalSeconds <= 0) {
+    return null;
+  }
+
+  const mean = weightedSum / totalSeconds;
+  const pulse = ((mean + 2) / 4) * 100;
+  return Math.min(100, Math.max(0, pulse));
+};

--- a/src/lib/rescuetime/rescuetime-goals-service.test.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.test.ts
@@ -81,7 +81,8 @@ describe("RescueTimeGoalsService", () => {
       expect.objectContaining({
         kind: "productivity",
         begin: "2026-08-02",
-        end: "2026-08-08"
+        end: "2026-08-08",
+        sourceType: "computers"
       })
     );
     expect(snapshot.weekStartDate).toBe("2026-08-02");

--- a/src/lib/rescuetime/rescuetime-goals-service.test.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.test.ts
@@ -52,4 +52,51 @@ describe("RescueTimeGoalsService", () => {
       })
     );
   });
+
+  it("computes productivity pulse for a week without schedule filter", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
+    });
+
+    const mockClient: RescueTimeGoalsClient = {
+      listGoals: vi.fn(async () => []),
+      fetchAnalyticData: vi.fn(async () => ({
+        row_headers: ["Rank", "Time Spent (seconds)", "Productivity"],
+        rows: [
+          [1, 3600, 2],
+          [2, 3600, 0]
+        ]
+      })),
+      fetchProjectTimes: vi.fn(async () => ({ project_times: [] }))
+    };
+
+    const service = new RescueTimeGoalsService(repository, mockClient);
+    const snapshot = await service.computeProductivityPulse("2026-08-02");
+
+    expect(mockClient.fetchAnalyticData).toHaveBeenCalledWith(
+      "rt-test-key",
+      expect.objectContaining({
+        kind: "productivity",
+        begin: "2026-08-02",
+        end: "2026-08-08"
+      })
+    );
+    expect(snapshot.weekStartDate).toBe("2026-08-02");
+    expect(snapshot.pulse).toBe(75);
+    expect(snapshot.fetchError).toBeUndefined();
+  });
+
+  it("returns null pulse when RescueTime is not configured", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const service = new RescueTimeGoalsService(repository);
+    const snapshot = await service.computeProductivityPulse("2026-08-02");
+
+    expect(snapshot.rescuetimeConfigured).toBe(false);
+    expect(snapshot.pulse).toBeNull();
+  });
 });

--- a/src/lib/rescuetime/rescuetime-goals-service.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.ts
@@ -210,7 +210,8 @@ export class RescueTimeGoalsService {
       const payload = await this.client.fetchAnalyticData(apiKey, {
         kind: "productivity",
         begin: normalized,
-        end: weekEndDate
+        end: weekEndDate,
+        sourceType: "computers"
       });
       const rows = parseProductivityRows(payload);
       const pulse = computeProductivityPulse(rows);

--- a/src/lib/rescuetime/rescuetime-goals-service.ts
+++ b/src/lib/rescuetime/rescuetime-goals-service.ts
@@ -22,6 +22,7 @@ import {
   resolveAnalyticKind,
   type RescueTimeGoalsClient
 } from "./goals-client";
+import { computeProductivityPulse } from "./productivity-mapping";
 
 interface AnalyticCache {
   productivity: Map<number, ReturnType<typeof parseProductivityRows>>;
@@ -36,6 +37,14 @@ const createAnalyticCache = (): AnalyticCache => ({
   category: new Map(),
   activity: new Map()
 });
+
+export interface RescueTimeProductivityPulseSnapshot {
+  weekStartDate: string;
+  weekEndDate: string;
+  pulse: number | null;
+  rescuetimeConfigured: boolean;
+  fetchError?: string;
+}
 
 export class RescueTimeGoalsService {
   constructor(
@@ -179,6 +188,50 @@ export class RescueTimeGoalsService {
     const rankKind = analyticKind as "overview" | "category" | "activity";
     const rows = await this.loadRankRows(apiKey, rankKind, weekStart, weekEnd, scheduleId, caches);
     return matchRankRowSeconds(rows, goal, rankKind);
+  }
+
+  async computeProductivityPulse(weekStartDate: string): Promise<RescueTimeProductivityPulseSnapshot> {
+    const normalized = buildWeekDates(weekStartDate);
+    const weekEndDate = addDays(normalized, 6);
+    const settings = await this.repository.getSettings();
+    const apiKey = settings.rescuetimeApiKey.trim();
+    const rescuetimeConfigured = apiKey.length > 0;
+
+    if (!rescuetimeConfigured) {
+      return {
+        weekStartDate: normalized,
+        weekEndDate,
+        pulse: null,
+        rescuetimeConfigured
+      };
+    }
+
+    try {
+      const payload = await this.client.fetchAnalyticData(apiKey, {
+        kind: "productivity",
+        begin: normalized,
+        end: weekEndDate
+      });
+      const rows = parseProductivityRows(payload);
+      const pulse = computeProductivityPulse(rows);
+
+      return {
+        weekStartDate: normalized,
+        weekEndDate,
+        pulse,
+        rescuetimeConfigured
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Echec de la requete RescueTime productivity.";
+      return {
+        weekStartDate: normalized,
+        weekEndDate,
+        pulse: null,
+        rescuetimeConfigured,
+        fetchError: message
+      };
+    }
   }
 
   async testConnection(apiKey: string): Promise<{ goalCount: number; sampleGoal?: string }> {

--- a/src/pages/WeeklyReviewPage.test.tsx
+++ b/src/pages/WeeklyReviewPage.test.tsx
@@ -1,6 +1,10 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createEmptyDailyEntry } from "../domain/daily-entry";
+import {
+  applyWeeklyScoreExternalAxes,
+  localWeeklyScoreAxes
+} from "../domain/weekly-review";
 import { MemoryRepository } from "../lib/storage/memory-repository";
 import { formatPercent } from "../lib/format";
 import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
@@ -14,6 +18,7 @@ describe("WeeklyReviewPage", () => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
+
   it("loads a week summary and saves ritual notes and checklist", async () => {
     const repository = new MemoryRepository();
     await repository.initialize();
@@ -190,12 +195,96 @@ describe("WeeklyReviewPage", () => {
     await user.click(screen.getByRole("button", { name: /charger la semaine/i }));
 
     const localSummary = await repository.computeWeeklyReviewSummary(weekStart);
+    const expected = applyWeeklyScoreExternalAxes(localSummary, {
+      rescueTimeGoalsScore: 1,
+      productivityPulse: 100
+    });
+    const localAxesSum = localWeeklyScoreAxes(localSummary).reduce((sum, value) => sum + value, 0);
+    expect(expected.weeklyScore).toBeCloseTo((localAxesSum + 1 + 1) / 9);
 
     await waitFor(() => {
       const scoreCard = screen.getAllByText("Score hebdo")[0].closest("article");
-      expect(scoreCard?.querySelector("strong")?.textContent).not.toBe(formatPercent(localSummary.weeklyScore));
+      expect(scoreCard?.querySelector("strong")?.textContent).toBe(formatPercent(expected.weeklyScore));
+    });
+  });
+
+  it("shows Goals results while the pulse request is still pending", async () => {
+    const weekStart = "2026-08-02";
+    type PulseSnapshot = {
+      weekStartDate: string;
+      weekEndDate: string;
+      pulse: number | null;
+      rescuetimeConfigured: boolean;
+    };
+    let resolvePulse: ((value: PulseSnapshot) => void) | undefined;
+
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeGoalsSnapshot").mockResolvedValue({
+      weekStartDate: weekStart,
+      weekEndDate: "2026-08-08",
+      score: 0.5,
+      totalAchievement: 0.5,
+      items: [
+        {
+          goalId: 1,
+          title: "pending-pulse goal",
+          isMore: true,
+          actualHours: 1,
+          weeklyTargetHours: 2,
+          achievement: 0.5,
+          scheduleLabel: "24x7"
+        }
+      ],
+      rescuetimeConfigured: true
+    });
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeProductivityPulse").mockImplementation(
+      () =>
+        new Promise<PulseSnapshot>((resolve) => {
+          resolvePulse = resolve;
+        })
+    );
+
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
     });
 
-    expect(localSummary.weeklyScore).toBeLessThan(0.5);
+    const user = userEvent.setup();
+    await renderWithApp(<WeeklyReviewPage />, {
+      repository,
+      route: "/semaine",
+      contextOverrides: {
+        settings: {
+          ...(await repository.getSettings()),
+          rescuetimeApiKey: "rt-test-key"
+        }
+      }
+    });
+
+    const dateInput = await screen.findByLabelText(/debut de semaine/i);
+    await user.clear(dateInput);
+    await user.type(dateInput, weekStart);
+    await user.click(screen.getByRole("button", { name: /charger la semaine/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("pending-pulse goal")).toBeInTheDocument();
+      expect(screen.getByText("0.50/1")).toBeInTheDocument();
+    });
+
+    const refreshButton = screen.getByRole("button", { name: /rafraichir rescuetime/i });
+    expect(refreshButton).not.toBeDisabled();
+
+    expect(resolvePulse).toBeDefined();
+    resolvePulse!({
+      weekStartDate: weekStart,
+      weekEndDate: "2026-08-08",
+      pulse: 90,
+      rescuetimeConfigured: true
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("90 / 100").length).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/pages/WeeklyReviewPage.test.tsx
+++ b/src/pages/WeeklyReviewPage.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createEmptyDailyEntry } from "../domain/daily-entry";
 import { MemoryRepository } from "../lib/storage/memory-repository";
+import { formatPercent } from "../lib/format";
 import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
 import { renderWithApp } from "../test/test-utils";
 import { WeeklyReviewPage } from "./WeeklyReviewPage";
@@ -87,6 +88,12 @@ describe("WeeklyReviewPage", () => {
     };
 
     vi.spyOn(RescueTimeGoalsService.prototype, "computeGoalsSnapshot").mockResolvedValue(goalsSnapshot);
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeProductivityPulse").mockResolvedValue({
+      weekStartDate: "2026-08-02",
+      weekEndDate: "2026-08-08",
+      pulse: null,
+      rescuetimeConfigured: true
+    });
 
     const repository = new MemoryRepository();
     await repository.initialize();
@@ -118,5 +125,77 @@ describe("WeeklyReviewPage", () => {
       expect(screen.getByText("more than 2h on Personal (24x7)")).toBeInTheDocument();
       expect(screen.getByText("0.25/1")).toBeInTheDocument();
     });
+  });
+
+  it("overlays RescueTime axes into the weekly score when snapshots match the week", async () => {
+    const weekStart = "2026-08-02";
+    const goalsSnapshot = {
+      weekStartDate: weekStart,
+      weekEndDate: "2026-08-08",
+      score: 1,
+      totalAchievement: 1,
+      items: [],
+      rescuetimeConfigured: true
+    };
+    const pulseSnapshot = {
+      weekStartDate: weekStart,
+      weekEndDate: "2026-08-08",
+      pulse: 100,
+      rescuetimeConfigured: true
+    };
+
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeGoalsSnapshot").mockResolvedValue(goalsSnapshot);
+    vi.spyOn(RescueTimeGoalsService.prototype, "computeProductivityPulse").mockResolvedValue(pulseSnapshot);
+
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const weekDates = [
+      weekStart,
+      "2026-08-03",
+      "2026-08-04",
+      "2026-08-05",
+      "2026-08-06",
+      "2026-08-07",
+      "2026-08-08"
+    ];
+
+    for (const date of weekDates) {
+      const entry = createEmptyDailyEntry(date);
+      entry.metrics.qualiteSommeil = 80;
+      entry.principleChecks.priereDuMatin = true;
+      await repository.saveDailyEntry(entry);
+    }
+
+    await repository.saveSettings({
+      ...(await repository.getSettings()),
+      rescuetimeApiKey: "rt-test-key"
+    });
+
+    const user = userEvent.setup();
+    await renderWithApp(<WeeklyReviewPage />, {
+      repository,
+      route: "/semaine",
+      contextOverrides: {
+        settings: {
+          ...(await repository.getSettings()),
+          rescuetimeApiKey: "rt-test-key"
+        }
+      }
+    });
+
+    const dateInput = await screen.findByLabelText(/debut de semaine/i);
+    await user.clear(dateInput);
+    await user.type(dateInput, weekStart);
+    await user.click(screen.getByRole("button", { name: /charger la semaine/i }));
+
+    const localSummary = await repository.computeWeeklyReviewSummary(weekStart);
+
+    await waitFor(() => {
+      const scoreCard = screen.getAllByText("Score hebdo")[0].closest("article");
+      expect(scoreCard?.querySelector("strong")?.textContent).not.toBe(formatPercent(localSummary.weeklyScore));
+    });
+
+    expect(localSummary.weeklyScore).toBeLessThan(0.5);
   });
 });

--- a/src/pages/WeeklyReviewPage.tsx
+++ b/src/pages/WeeklyReviewPage.tsx
@@ -115,67 +115,110 @@ export const WeeklyReviewPage = () => {
   const [summary, setSummary] = useState<WeeklyReviewSummary | null>(null);
   const [goalsSnapshot, setGoalsSnapshot] = useState<RescueTimeGoalsSnapshot | null>(null);
   const [pulseSnapshot, setPulseSnapshot] = useState<RescueTimeProductivityPulseSnapshot | null>(null);
-  const [rescueTimeLoading, setRescueTimeLoading] = useState(true);
-  const [rescueTimeRefreshing, setRescueTimeRefreshing] = useState(false);
+  const [goalsLoading, setGoalsLoading] = useState(true);
+  const [pulseLoading, setPulseLoading] = useState(true);
+  const [goalsRefreshing, setGoalsRefreshing] = useState(false);
+  const [pulseRefreshing, setPulseRefreshing] = useState(false);
   const [rescueTimeMessage, setRescueTimeMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const latestReviewRef = useRef<WeeklyReview | null>(null);
   const weekRequestSeqRef = useRef(0);
-  const rescueTimeRequestSeqRef = useRef(0);
+  const goalsRequestSeqRef = useRef(0);
+  const pulseRequestSeqRef = useRef(0);
 
-  const loadRescueTimeData = useCallback(
-    async (requestedWeekStart: string) => {
-      const requestId = ++rescueTimeRequestSeqRef.current;
-      setRescueTimeLoading(true);
+  const loadGoalsSnapshot = useCallback(
+    async (requestedWeekStart: string, options?: { refreshing?: boolean }) => {
+      const requestId = ++goalsRequestSeqRef.current;
+      if (options?.refreshing) {
+        setGoalsRefreshing(true);
+      } else {
+        setGoalsLoading(true);
+      }
       setRescueTimeMessage("");
       try {
-        const [goals, pulse] = await Promise.all([
-          goalsService.computeGoalsSnapshot(requestedWeekStart),
-          goalsService.computeProductivityPulse(requestedWeekStart)
-        ]);
-        if (requestId !== rescueTimeRequestSeqRef.current) {
+        const goals = await goalsService.computeGoalsSnapshot(requestedWeekStart);
+        if (requestId !== goalsRequestSeqRef.current) {
           return;
         }
         setGoalsSnapshot(goals);
-        setPulseSnapshot(pulse);
+      } catch (error) {
+        if (requestId !== goalsRequestSeqRef.current) {
+          return;
+        }
+        if (options?.refreshing) {
+          setRescueTimeMessage(
+            error instanceof Error ? error.message : "Echec du rafraichissement RescueTime Goals."
+          );
+        }
       } finally {
-        if (requestId === rescueTimeRequestSeqRef.current) {
-          setRescueTimeLoading(false);
+        if (requestId === goalsRequestSeqRef.current) {
+          if (options?.refreshing) {
+            setGoalsRefreshing(false);
+          } else {
+            setGoalsLoading(false);
+          }
         }
       }
     },
     [goalsService]
   );
 
-  const refreshRescueTimeData = useCallback(
-    async (requestedWeekStart: string) => {
-      const requestId = ++rescueTimeRequestSeqRef.current;
-      setRescueTimeRefreshing(true);
+  const loadPulseSnapshot = useCallback(
+    async (requestedWeekStart: string, options?: { refreshing?: boolean }) => {
+      const requestId = ++pulseRequestSeqRef.current;
+      if (options?.refreshing) {
+        setPulseRefreshing(true);
+      } else {
+        setPulseLoading(true);
+      }
       setRescueTimeMessage("");
       try {
-        const [goals, pulse] = await Promise.all([
-          goalsService.computeGoalsSnapshot(requestedWeekStart),
-          goalsService.computeProductivityPulse(requestedWeekStart)
-        ]);
-        if (requestId !== rescueTimeRequestSeqRef.current) {
+        const pulse = await goalsService.computeProductivityPulse(requestedWeekStart);
+        if (requestId !== pulseRequestSeqRef.current) {
           return;
         }
-        setGoalsSnapshot(goals);
         setPulseSnapshot(pulse);
       } catch (error) {
-        if (requestId !== rescueTimeRequestSeqRef.current) {
+        if (requestId !== pulseRequestSeqRef.current) {
           return;
         }
-        setRescueTimeMessage(
-          error instanceof Error ? error.message : "Echec du rafraichissement RescueTime."
-        );
+        if (options?.refreshing) {
+          setRescueTimeMessage(
+            error instanceof Error ? error.message : "Echec du rafraichissement RescueTime pulse."
+          );
+        }
       } finally {
-        if (requestId === rescueTimeRequestSeqRef.current) {
-          setRescueTimeRefreshing(false);
+        if (requestId === pulseRequestSeqRef.current) {
+          if (options?.refreshing) {
+            setPulseRefreshing(false);
+          } else {
+            setPulseLoading(false);
+          }
         }
       }
     },
     [goalsService]
+  );
+
+  const loadRescueTimeData = useCallback(
+    (requestedWeekStart: string) => {
+      setGoalsSnapshot(null);
+      setPulseSnapshot(null);
+      setGoalsRefreshing(false);
+      setPulseRefreshing(false);
+      setRescueTimeMessage("");
+      void loadGoalsSnapshot(requestedWeekStart);
+      void loadPulseSnapshot(requestedWeekStart);
+    },
+    [loadGoalsSnapshot, loadPulseSnapshot]
+  );
+
+  const refreshRescueTimeData = useCallback(
+    (requestedWeekStart: string) => {
+      void loadGoalsSnapshot(requestedWeekStart, { refreshing: true });
+      void loadPulseSnapshot(requestedWeekStart, { refreshing: true });
+    },
+    [loadGoalsSnapshot, loadPulseSnapshot]
   );
 
   const loadWeek = useCallback(
@@ -261,6 +304,14 @@ export const WeeklyReviewPage = () => {
   if (loading || !review || !summary || !displayedSummary) {
     return <div className="page"><p>Chargement de la revue hebdomadaire...</p></div>;
   }
+
+  const weekMatchedGoalsSnapshot =
+    goalsSnapshot?.weekStartDate === summary.weekStartDate ? goalsSnapshot : null;
+  const weekMatchedPulseSnapshot =
+    pulseSnapshot?.weekStartDate === summary.weekStartDate ? pulseSnapshot : null;
+  const goalsBusy = goalsLoading || goalsRefreshing;
+  const pulseBusy = pulseLoading || pulseRefreshing;
+  const rescueTimeRefreshing = goalsRefreshing || pulseRefreshing;
 
   return (
     <div className="page">
@@ -377,7 +428,7 @@ export const WeeklyReviewPage = () => {
           <article className="status-card">
             <span>Productivite ordinateur</span>
             <strong>
-              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
+              {pulseBusy || !weekMatchedPulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
             </strong>
           </article>
           <article className="status-card">
@@ -404,28 +455,36 @@ export const WeeklyReviewPage = () => {
             <Link to="/parametres">Parametres</Link> pour charger tes goals RescueTime.
           </div>
         ) : null}
-        {goalsSnapshot?.fetchError ? <div className="banner">{goalsSnapshot.fetchError}</div> : null}
-        {pulseSnapshot?.fetchError ? <div className="banner">{pulseSnapshot.fetchError}</div> : null}
+        {weekMatchedGoalsSnapshot?.fetchError ? (
+          <div className="banner">{weekMatchedGoalsSnapshot.fetchError}</div>
+        ) : null}
+        {weekMatchedPulseSnapshot?.fetchError ? (
+          <div className="banner">{weekMatchedPulseSnapshot.fetchError}</div>
+        ) : null}
 
         <div className="weekly-overview-grid">
           <article className="status-card">
             <span>Score objectifs</span>
-            <strong>{rescueTimeLoading || !goalsSnapshot ? "..." : formatObjectiveScore(goalsSnapshot.score)}</strong>
+            <strong>
+              {goalsBusy || !weekMatchedGoalsSnapshot
+                ? "..."
+                : formatObjectiveScore(weekMatchedGoalsSnapshot.score)}
+            </strong>
           </article>
           <article className="status-card">
             <span>Points obtenus</span>
             <strong>
-              {rescueTimeLoading || !goalsSnapshot
+              {goalsBusy || !weekMatchedGoalsSnapshot
                 ? "..."
-                : goalsSnapshot.items.length === 0
+                : weekMatchedGoalsSnapshot.items.length === 0
                   ? "—"
-                  : `${goalsSnapshot.totalAchievement.toFixed(2)} / ${goalsSnapshot.items.length}`}
+                  : `${weekMatchedGoalsSnapshot.totalAchievement.toFixed(2)} / ${weekMatchedGoalsSnapshot.items.length}`}
             </strong>
           </article>
           <article className="status-card">
             <span>Productivite ordinateur</span>
             <strong>
-              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
+              {pulseBusy || !weekMatchedPulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
             </strong>
           </article>
           <article className="status-card">
@@ -438,20 +497,20 @@ export const WeeklyReviewPage = () => {
           <button
             className="button"
             type="button"
-            disabled={rescueTimeRefreshing || rescueTimeLoading || !settings.rescuetimeApiKey.trim()}
+            disabled={rescueTimeRefreshing || !settings.rescuetimeApiKey.trim()}
             onClick={() => void refreshRescueTimeData(summary.weekStartDate)}
           >
             {rescueTimeRefreshing ? "Rafraichissement..." : "Rafraichir RescueTime"}
           </button>
         </div>
 
-        {rescueTimeLoading || !goalsSnapshot ? (
+        {goalsBusy || !weekMatchedGoalsSnapshot ? (
           <p className="empty-copy">Chargement des objectifs RescueTime...</p>
-        ) : goalsSnapshot.fetchError ? null : goalsSnapshot.items.length === 0 ? (
+        ) : weekMatchedGoalsSnapshot.fetchError ? null : weekMatchedGoalsSnapshot.items.length === 0 ? (
           <p className="empty-copy">Aucun goal RescueTime actif trouve pour ce compte.</p>
         ) : (
           <div className="weekly-day-grid">
-            {goalsSnapshot.items.map((item) => (
+            {weekMatchedGoalsSnapshot.items.map((item) => (
               <article key={item.goalId} className="schedule-day-group">
                 <div className="schedule-day-group__header">
                   <h3>{item.title}</h3>
@@ -503,13 +562,15 @@ export const WeeklyReviewPage = () => {
           <article className="status-card">
             <span>Productivite ordinateur</span>
             <strong>
-              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
+              {pulseBusy || !weekMatchedPulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
             </strong>
           </article>
           <article className="status-card">
             <span>Score objectifs RescueTime</span>
             <strong>
-              {rescueTimeLoading || !goalsSnapshot ? "..." : formatObjectiveScore(displayedSummary.rescueTimeGoalsScore)}
+              {goalsBusy || !weekMatchedGoalsSnapshot
+                ? "..."
+                : formatObjectiveScore(displayedSummary.rescueTimeGoalsScore)}
             </strong>
           </article>
         </div>

--- a/src/pages/WeeklyReviewPage.tsx
+++ b/src/pages/WeeklyReviewPage.tsx
@@ -4,6 +4,7 @@ import { useAppContext } from "../app/app-context";
 import { deriveStatusLabel } from "../domain/daily-entry";
 import {
   applyWeeklyReviewTransition,
+  applyWeeklyScoreExternalAxes,
   buildWeekDates,
   createEmptyWeeklyReview,
   updateWeeklyReviewChecklist,
@@ -20,7 +21,7 @@ import { SectionCard } from "../components/SectionCard";
 import { formatDateLong, formatDateShort, getTodayDate } from "../lib/date";
 import { formatPercent, formatTimestamp } from "../lib/format";
 import { addDays } from "../lib/gtd/shared";
-import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
+import { RescueTimeGoalsService, type RescueTimeProductivityPulseSnapshot } from "../lib/rescuetime/rescuetime-goals-service";
 
 interface RitualSectionDefinition {
   key: WeeklyRitualSectionKey;
@@ -100,6 +101,9 @@ const formatHours = (hours: number | null): string =>
 const formatObjectiveScore = (score: number | null): string =>
   score === null ? "—" : formatPercent(score);
 
+const formatPulse = (value: number | null): string =>
+  value === null ? "—" : `${Math.round(value)} / 100`;
+
 const deriveWeeklyStatusLabel = (status: WeeklyReview["status"]): string =>
   status === "closed" ? "Revue cloturee" : "Brouillon";
 
@@ -110,53 +114,64 @@ export const WeeklyReviewPage = () => {
   const [review, setReview] = useState<WeeklyReview | null>(null);
   const [summary, setSummary] = useState<WeeklyReviewSummary | null>(null);
   const [goalsSnapshot, setGoalsSnapshot] = useState<RescueTimeGoalsSnapshot | null>(null);
-  const [goalsLoading, setGoalsLoading] = useState(true);
-  const [goalsRefreshing, setGoalsRefreshing] = useState(false);
-  const [goalsMessage, setGoalsMessage] = useState("");
+  const [pulseSnapshot, setPulseSnapshot] = useState<RescueTimeProductivityPulseSnapshot | null>(null);
+  const [rescueTimeLoading, setRescueTimeLoading] = useState(true);
+  const [rescueTimeRefreshing, setRescueTimeRefreshing] = useState(false);
+  const [rescueTimeMessage, setRescueTimeMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const latestReviewRef = useRef<WeeklyReview | null>(null);
   const weekRequestSeqRef = useRef(0);
-  const goalsRequestSeqRef = useRef(0);
+  const rescueTimeRequestSeqRef = useRef(0);
 
-  const loadGoalsSnapshot = useCallback(
+  const loadRescueTimeData = useCallback(
     async (requestedWeekStart: string) => {
-      const requestId = ++goalsRequestSeqRef.current;
-      setGoalsLoading(true);
-      setGoalsMessage("");
+      const requestId = ++rescueTimeRequestSeqRef.current;
+      setRescueTimeLoading(true);
+      setRescueTimeMessage("");
       try {
-        const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
-        if (requestId !== goalsRequestSeqRef.current) {
+        const [goals, pulse] = await Promise.all([
+          goalsService.computeGoalsSnapshot(requestedWeekStart),
+          goalsService.computeProductivityPulse(requestedWeekStart)
+        ]);
+        if (requestId !== rescueTimeRequestSeqRef.current) {
           return;
         }
-        setGoalsSnapshot(snapshot);
+        setGoalsSnapshot(goals);
+        setPulseSnapshot(pulse);
       } finally {
-        if (requestId === goalsRequestSeqRef.current) {
-          setGoalsLoading(false);
+        if (requestId === rescueTimeRequestSeqRef.current) {
+          setRescueTimeLoading(false);
         }
       }
     },
     [goalsService]
   );
 
-  const refreshGoalsSnapshot = useCallback(
+  const refreshRescueTimeData = useCallback(
     async (requestedWeekStart: string) => {
-      const requestId = ++goalsRequestSeqRef.current;
-      setGoalsRefreshing(true);
-      setGoalsMessage("");
+      const requestId = ++rescueTimeRequestSeqRef.current;
+      setRescueTimeRefreshing(true);
+      setRescueTimeMessage("");
       try {
-        const snapshot = await goalsService.computeGoalsSnapshot(requestedWeekStart);
-        if (requestId !== goalsRequestSeqRef.current) {
+        const [goals, pulse] = await Promise.all([
+          goalsService.computeGoalsSnapshot(requestedWeekStart),
+          goalsService.computeProductivityPulse(requestedWeekStart)
+        ]);
+        if (requestId !== rescueTimeRequestSeqRef.current) {
           return;
         }
-        setGoalsSnapshot(snapshot);
+        setGoalsSnapshot(goals);
+        setPulseSnapshot(pulse);
       } catch (error) {
-        if (requestId !== goalsRequestSeqRef.current) {
+        if (requestId !== rescueTimeRequestSeqRef.current) {
           return;
         }
-        setGoalsMessage(error instanceof Error ? error.message : "Echec du rafraichissement RescueTime.");
+        setRescueTimeMessage(
+          error instanceof Error ? error.message : "Echec du rafraichissement RescueTime."
+        );
       } finally {
-        if (requestId === goalsRequestSeqRef.current) {
-          setGoalsRefreshing(false);
+        if (requestId === rescueTimeRequestSeqRef.current) {
+          setRescueTimeRefreshing(false);
         }
       }
     },
@@ -181,14 +196,14 @@ export const WeeklyReviewPage = () => {
         setSelectedWeekStart(normalized);
         setReview(nextReview);
         setSummary(computedSummary);
-        void loadGoalsSnapshot(normalized);
+        void loadRescueTimeData(normalized);
       } finally {
         if (requestId === weekRequestSeqRef.current) {
           setLoading(false);
         }
       }
     },
-    [loadGoalsSnapshot, repository]
+    [loadRescueTimeData, repository]
   );
 
   useEffect(() => {
@@ -223,11 +238,27 @@ export const WeeklyReviewPage = () => {
     previousRescuetimeApiKeyRef.current = settings.rescuetimeApiKey;
 
     if (hasValidSelectedWeek) {
-      void loadGoalsSnapshot(selectedWeekStart);
+      void loadRescueTimeData(selectedWeekStart);
     }
-  }, [settings.rescuetimeApiKey, hasValidSelectedWeek, loadGoalsSnapshot, selectedWeekStart]);
+  }, [settings.rescuetimeApiKey, hasValidSelectedWeek, loadRescueTimeData, selectedWeekStart]);
 
-  if (loading || !review || !summary) {
+  const displayedSummary = useMemo(() => {
+    if (!summary) {
+      return null;
+    }
+
+    const rescueTimeGoalsScore =
+      goalsSnapshot?.weekStartDate === summary.weekStartDate ? goalsSnapshot.score : null;
+    const productivityPulse =
+      pulseSnapshot?.weekStartDate === summary.weekStartDate ? pulseSnapshot.pulse : null;
+
+    return applyWeeklyScoreExternalAxes(summary, {
+      rescueTimeGoalsScore,
+      productivityPulse
+    });
+  }, [goalsSnapshot, pulseSnapshot, summary]);
+
+  if (loading || !review || !summary || !displayedSummary) {
     return <div className="page"><p>Chargement de la revue hebdomadaire...</p></div>;
   }
 
@@ -321,7 +352,7 @@ export const WeeklyReviewPage = () => {
           </article>
           <article className="status-card">
             <span>Score hebdo</span>
-            <strong>{formatPercent(summary.weeklyScore)}</strong>
+            <strong>{formatPercent(displayedSummary.weeklyScore)}</strong>
           </article>
           <article className="status-card">
             <span>Sommeil moyen</span>
@@ -340,6 +371,16 @@ export const WeeklyReviewPage = () => {
             <strong>{summary.pomodorisTotal}</strong>
           </article>
           <article className="status-card">
+            <span>Depense calorique moyenne</span>
+            <strong>{Math.round(summary.calorieAverage)} kcal</strong>
+          </article>
+          <article className="status-card">
+            <span>Productivite ordinateur</span>
+            <strong>
+              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
+            </strong>
+          </article>
+          <article className="status-card">
             <span>Discipline moyenne</span>
             <strong>{formatWholePercent(summary.disciplineAverage * 100)}</strong>
           </article>
@@ -356,7 +397,7 @@ export const WeeklyReviewPage = () => {
         title="Objectifs de la semaine"
         subtitle="Score base sur tes RescueTime Goals: chaque objectif vaut au plus 1 point, avec scoring fractionnel sur le temps."
       >
-        {goalsMessage ? <div className="banner">{goalsMessage}</div> : null}
+        {rescueTimeMessage ? <div className="banner">{rescueTimeMessage}</div> : null}
         {!settings.rescuetimeApiKey.trim() ? (
           <div className="banner">
             Cle RescueTime manquante. Configure-la dans{" "}
@@ -364,20 +405,27 @@ export const WeeklyReviewPage = () => {
           </div>
         ) : null}
         {goalsSnapshot?.fetchError ? <div className="banner">{goalsSnapshot.fetchError}</div> : null}
+        {pulseSnapshot?.fetchError ? <div className="banner">{pulseSnapshot.fetchError}</div> : null}
 
         <div className="weekly-overview-grid">
           <article className="status-card">
             <span>Score objectifs</span>
-            <strong>{goalsLoading || !goalsSnapshot ? "..." : formatObjectiveScore(goalsSnapshot.score)}</strong>
+            <strong>{rescueTimeLoading || !goalsSnapshot ? "..." : formatObjectiveScore(goalsSnapshot.score)}</strong>
           </article>
           <article className="status-card">
             <span>Points obtenus</span>
             <strong>
-              {goalsLoading || !goalsSnapshot
+              {rescueTimeLoading || !goalsSnapshot
                 ? "..."
                 : goalsSnapshot.items.length === 0
                   ? "—"
                   : `${goalsSnapshot.totalAchievement.toFixed(2)} / ${goalsSnapshot.items.length}`}
+            </strong>
+          </article>
+          <article className="status-card">
+            <span>Productivite ordinateur</span>
+            <strong>
+              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
             </strong>
           </article>
           <article className="status-card">
@@ -390,14 +438,14 @@ export const WeeklyReviewPage = () => {
           <button
             className="button"
             type="button"
-            disabled={goalsRefreshing || goalsLoading || !settings.rescuetimeApiKey.trim()}
-            onClick={() => void refreshGoalsSnapshot(summary.weekStartDate)}
+            disabled={rescueTimeRefreshing || rescueTimeLoading || !settings.rescuetimeApiKey.trim()}
+            onClick={() => void refreshRescueTimeData(summary.weekStartDate)}
           >
-            {goalsRefreshing ? "Rafraichissement..." : "Rafraichir RescueTime Goals"}
+            {rescueTimeRefreshing ? "Rafraichissement..." : "Rafraichir RescueTime"}
           </button>
         </div>
 
-        {goalsLoading || !goalsSnapshot ? (
+        {rescueTimeLoading || !goalsSnapshot ? (
           <p className="empty-copy">Chargement des objectifs RescueTime...</p>
         ) : goalsSnapshot.fetchError ? null : goalsSnapshot.items.length === 0 ? (
           <p className="empty-copy">Aucun goal RescueTime actif trouve pour ce compte.</p>
@@ -437,8 +485,12 @@ export const WeeklyReviewPage = () => {
             <strong>{formatWholePercent(summary.phoneScreenTime)}</strong>
           </article>
           <article className="status-card">
-            <span>Score pomodoris</span>
+            <span>Score temps focus</span>
             <strong>{formatWholePercent(summary.pomodoris)}</strong>
+          </article>
+          <article className="status-card">
+            <span>Activite physique</span>
+            <strong>{formatWholePercent(summary.physicalActivity)}</strong>
           </article>
           <article className="status-card">
             <span>Score discipline</span>
@@ -447,6 +499,18 @@ export const WeeklyReviewPage = () => {
           <article className="status-card">
             <span>Taux de completion</span>
             <strong>{formatWholePercent(summary.tasksCompletionRate)}</strong>
+          </article>
+          <article className="status-card">
+            <span>Productivite ordinateur</span>
+            <strong>
+              {rescueTimeLoading || !pulseSnapshot ? "..." : formatPulse(displayedSummary.productivityPulse)}
+            </strong>
+          </article>
+          <article className="status-card">
+            <span>Score objectifs RescueTime</span>
+            <strong>
+              {rescueTimeLoading || !goalsSnapshot ? "..." : formatObjectiveScore(displayedSummary.rescueTimeGoalsScore)}
+            </strong>
           </article>
         </div>
       </SectionCard>
@@ -464,6 +528,7 @@ export const WeeklyReviewPage = () => {
                 <span>TRC: {day.trcRespected ? "Oui" : "Non"}</span>
                 <span>Ecran: {day.screenTimeMinutes} min</span>
                 <span>Pomodoris: {day.pomodoris}</span>
+                <span>Kcal: {day.calorieExpenditure}</span>
                 <span>Discipline: {formatWholePercent(day.disciplineScore * 100)}</span>
                 <span>
                   Taches: {day.tasksCompleted}/{day.tasksAdded}


### PR DESCRIPTION
## Summary
- Expand Score hebdo on `/semaine` to nine axes: physical activity (`depenseCalorique` vs 3800 kcal/day avg), sleep, TRC, phone screen, task completion, discipline, RescueTime Goals, computer productivity pulse, and focused time (Pomodoro).
- Fetch Sunday–Saturday RescueTime productivity pulse via Analytic Data (`restrict_kind=productivity`) and fold Goals + pulse into the weekly score only when non-null and week-matched; monthly/annual stay on the local 7-axis mean.
- Includes the RescueTime Goals weekly scoring work (formerly stacked on #49) plus the calorie/pulse weekly-score overlay.
- Update weekly review UI, domain tests, and docs for the new formula and API usage.

## Review process
- Went through `plan-review` first (1 iteration → approved).
- Went through `develop-review` (first-pass approval, 0 fix cycles).
- Replaces closed #50 (retargeted to `master` after the previous base branch was removed).

## Test plan
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] On `/semaine` with RescueTime key: Score hebdo updates after Goals + pulse load; calorie average and pulse shown
- [ ] Without RescueTime key: Score hebdo stays 7-axis local; pulse/goals show `—`
- [ ] Switch weeks: previous week’s RescueTime values do not affect the new week’s score until matching snapshots arrive
- [ ] `/mois` / annual weekly score pick up calories but not RescueTime overlays


Made with [Cursor](https://cursor.com)