### PR TITLE
Finalize yesterday's daily entry from the morning routine

### DIFF
--- a/docs/daily-routines.md
+++ b/docs/daily-routines.md
@@ -62,6 +62,40 @@ Morning/anytime principles:
 
 Principle values are tri-state: `true`, `false`, or `null` (not answered).
 
+### Finalizing yesterday from the morning screen
+
+The morning screen also renders a `PreviousDayReviewCard` above the intention
+section. It targets strictly `addDays(getTodayDate(), -1)` (yesterday), not the
+last day with data, and never changes yesterday's `DailyStatus`.
+
+The card shows only what is still missing for yesterday:
+
+- manual metrics where `resolveMetricValue` is `null` (`findMissingMetricKeys`);
+  auto-suggested metrics (`tachesDebut/Fin/Ajoutes/Realises`, `pomodoris`) are
+  never "missing" since they always resolve from `suggestedMetrics`;
+- principles still `null` (`findUnansweredPrincipleKeys`); an explicit `false` is
+  a real answer and is not re-asked;
+- the night reflection, if empty.
+
+The set of missing fields is frozen on first load of yesterday's entry, so a
+field does not disappear mid-edit as soon as the user answers it. The card
+reuses `useDailyEntry`, `MetricGrid`, `PrincipleChecklist`, and
+`PersistedTextarea` (`debounceMs={0}`) exactly as the other daily screens do,
+edited as a local draft like `HistoryPage`.
+
+A single "Enregistrer hier" button saves everything at once:
+
+- yesterday's entry is only saved (`useDailyEntry.save`) if at least one missing
+  field actually changed, to avoid creating an empty `daily_entries` row for a
+  day that was never opened;
+- `AppSettings.previousDayReviewDoneDate` is always set to yesterday's date,
+  even when nothing changed, so the card does not resurface for that day.
+
+The card hides itself (renders nothing) when `previousDayReviewDoneDate` already
+equals yesterday, while loading, or when nothing is missing (auto-hide). No
+SQLite migration was needed for the new settings field: `app_settings` is a
+JSON blob merged with `defaultAppSettings()` on read.
+
 ## Evening closure (`/fermeture-soir`)
 
 The evening screen exposes:

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,7 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-08-29 | Added a "Finaliser hier" card on `/routine-matin` that shows only yesterday's still-missing manual metrics, unanswered principles, and empty night reflection, saved via one button and hidden by `AppSettings.previousDayReviewDoneDate` | `docs/daily-routines.md` | `src/domain/daily-entry.ts` (`findMissingMetricKeys`, `findUnansweredPrincipleKeys`), `src/components/PreviousDayReviewCard.tsx`, `src/pages/MorningRoutinePage.tsx` |
 | 2026-08-13 | Added `npm run mac-install` to copy the release `Trackdidia.app` into `/Applications` | `docs/desktop-builds.md` | `scripts/mac-install.sh`, `package.json` |
 | 2026-08-12 | Weekly score: seven local axes (calories at 3800 kcal/day), optional RescueTime Goals + productivity pulse overlay on `/semaine` | `docs/reviews-and-goals.md`, `docs/ai-settings-and-privacy.md` | `src/domain/weekly-review.ts`, `src/lib/rescuetime/rescuetime-goals-service.ts`, weekly review page |
 | 2026-08-12 | Retry Pomodoro history/summary snapshots after a transient list-read failure so the page cannot stay on pre-action history after the active session already updated | `docs/recurrences-and-pomodoro.md` | `src/app/use-pomodoro-controller.ts`, Pomodoro controller tests |

--- a/src/components/PreviousDayReviewCard.test.tsx
+++ b/src/components/PreviousDayReviewCard.test.tsx
@@ -1,0 +1,124 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createEmptyDailyEntry, defaultAppSettings } from "../domain/daily-entry";
+import { MemoryRepository } from "../lib/storage/memory-repository";
+import { MorningRoutinePage } from "../pages/MorningRoutinePage";
+import { addDays } from "../lib/gtd/shared";
+import { getTodayDate } from "../lib/date";
+import { renderWithApp } from "../test/test-utils";
+
+const yesterday = addDays(getTodayDate(), -1);
+
+describe("PreviousDayReviewCard", () => {
+  it("shows only the fields still missing for yesterday", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    const seeded = createEmptyDailyEntry(yesterday);
+    seeded.metrics.qualiteSommeil = 80;
+    seeded.principleChecks.priereDuSoir = false;
+    seeded.principleChecks.retroJournalier = null;
+    seeded.nightReflection = "";
+    await repository.saveDailyEntry(seeded);
+
+    await renderWithApp(<MorningRoutinePage />, { repository });
+
+    await screen.findByText("Finaliser hier");
+
+    expect(screen.getByText("Marche")).toBeInTheDocument();
+    expect(screen.getByText("Depense calorique")).toBeInTheDocument();
+    expect(screen.getByText("Retro journalier")).toBeInTheDocument();
+    expect(screen.getByText("Reflection du soir")).toBeInTheDocument();
+
+    expect(screen.queryByText("Qualite du sommeil")).not.toBeInTheDocument();
+    expect(screen.queryByText("Priere du soir")).not.toBeInTheDocument();
+  });
+
+  it("saves only the missing fields for yesterday and flags the settings, without touching today", async () => {
+    const user = userEvent.setup();
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    const seeded = createEmptyDailyEntry(yesterday);
+    seeded.metrics.qualiteSommeil = 80;
+    seeded.principleChecks.priereDuSoir = false;
+    seeded.principleChecks.retroJournalier = null;
+    seeded.nightReflection = "";
+    await repository.saveDailyEntry(seeded);
+
+    let savedSettings: unknown = null;
+    const settings = defaultAppSettings();
+    const saveSettings = vi.fn(async (next: typeof settings) => {
+      savedSettings = next;
+    });
+
+    await renderWithApp(<MorningRoutinePage />, {
+      repository,
+      contextOverrides: { settings, saveSettings }
+    });
+
+    await screen.findByText("Finaliser hier");
+
+    const marcheInput = screen.getByText("Marche").closest("label")!.querySelector("input")!;
+    await user.type(marcheInput, "8000");
+
+    const retroGroup = screen.getByRole("group", { name: /retro journalier/i });
+    await user.click(within(retroGroup).getByRole("button", { name: /oui/i }));
+
+    const reflection = screen.getByText("Reflection du soir").closest("label")!.querySelector("textarea")!;
+    await user.type(reflection, "Bonne journee.");
+
+    await user.click(screen.getByRole("button", { name: /enregistrer hier/i }));
+
+    const savedYesterday = await repository.getDailyEntry(yesterday);
+    expect(savedYesterday?.metrics.marche).toBe(8000);
+    expect(savedYesterday?.principleChecks.retroJournalier).toBe(true);
+    expect(savedYesterday?.nightReflection).toBe("Bonne journee.");
+
+    const savedToday = await repository.getDailyEntry(getTodayDate());
+    expect(savedToday).toBeNull();
+
+    expect(saveSettings).toHaveBeenCalled();
+    expect((savedSettings as { previousDayReviewDoneDate: string } | null)?.previousDayReviewDoneDate).toBe(
+      yesterday
+    );
+  });
+
+  it("hides the card when the flag already covers yesterday", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    const seeded = createEmptyDailyEntry(yesterday);
+    seeded.nightReflection = "";
+    await repository.saveDailyEntry(seeded);
+
+    await renderWithApp(<MorningRoutinePage />, {
+      repository,
+      contextOverrides: {
+        settings: { ...defaultAppSettings(), previousDayReviewDoneDate: yesterday }
+      }
+    });
+
+    await screen.findByRole("textbox", { name: /intention/i });
+    expect(screen.queryByText("Finaliser hier")).not.toBeInTheDocument();
+  });
+
+  it("auto-hides when nothing is missing for yesterday", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    const seeded = createEmptyDailyEntry(yesterday);
+    seeded.metrics.course = 30;
+    seeded.metrics.marche = 8000;
+    seeded.metrics.depenseCalorique = 2200;
+    seeded.metrics.pushups = 20;
+    seeded.metrics.qualiteSommeil = 80;
+    seeded.metrics.tempsEcranTelephone = 60;
+    for (const key of Object.keys(seeded.principleChecks) as Array<keyof typeof seeded.principleChecks>) {
+      seeded.principleChecks[key] = true;
+    }
+    seeded.nightReflection = "Journee cloturee.";
+    await repository.saveDailyEntry(seeded);
+
+    await renderWithApp(<MorningRoutinePage />, { repository });
+
+    await screen.findByRole("textbox", { name: /intention/i });
+    expect(screen.queryByText("Finaliser hier")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/PreviousDayReviewCard.tsx
+++ b/src/components/PreviousDayReviewCard.tsx
@@ -71,40 +71,42 @@ export const PreviousDayReviewCard = ({ date }: PreviousDayReviewCardProps) => {
       title="Finaliser hier"
       subtitle={`${formatDateLong(date)} - complete ce qui n'a pas encore ete rempli hier soir.`}
     >
-      {missing.metricKeys.length > 0 ? (
-        <MetricGrid
-          entry={draft}
-          keys={missing.metricKeys}
-          suggestionKeys={[...autoSuggestedMetricKeys]}
-          suggestedValues={draft.suggestedMetrics}
-          onChange={(key, value) => setDraft(updateMetric(draft, key, value))}
-        />
-      ) : null}
-
-      {missing.principleKeys.length > 0 ? (
-        <PrincipleChecklist
-          entry={draft}
-          keys={missing.principleKeys}
-          onChange={(key, value) => setDraft(updatePrinciple(draft, key, value))}
-        />
-      ) : null}
-
-      {missing.nightReflection ? (
-        <label className="stacked-field">
-          <span>Reflection du soir</span>
-          <PersistedTextarea
-            rows={4}
-            debounceMs={0}
-            savedValue={draft.nightReflection}
-            onPersist={(value) => setDraft(updateNote(draft, "nightReflection", value))}
+      <div className="section-stack">
+        {missing.metricKeys.length > 0 ? (
+          <MetricGrid
+            entry={draft}
+            keys={missing.metricKeys}
+            suggestionKeys={[...autoSuggestedMetricKeys]}
+            suggestedValues={draft.suggestedMetrics}
+            onChange={(key, value) => setDraft(updateMetric(draft, key, value))}
           />
-        </label>
-      ) : null}
+        ) : null}
 
-      <div className="form-actions">
-        <button className="button button--primary" type="button" onClick={() => void handleSave()}>
-          Enregistrer hier
-        </button>
+        {missing.principleKeys.length > 0 ? (
+          <PrincipleChecklist
+            entry={draft}
+            keys={missing.principleKeys}
+            onChange={(key, value) => setDraft(updatePrinciple(draft, key, value))}
+          />
+        ) : null}
+
+        {missing.nightReflection ? (
+          <label className="stacked-field">
+            <span>Reflection du soir</span>
+            <PersistedTextarea
+              rows={4}
+              debounceMs={0}
+              savedValue={draft.nightReflection}
+              onPersist={(value) => setDraft(updateNote(draft, "nightReflection", value))}
+            />
+          </label>
+        ) : null}
+
+        <div className="form-actions">
+          <button className="button button--primary" type="button" onClick={() => void handleSave()}>
+            Enregistrer hier
+          </button>
+        </div>
       </div>
     </SectionCard>
   );

--- a/src/components/PreviousDayReviewCard.tsx
+++ b/src/components/PreviousDayReviewCard.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { autoSuggestedMetricKeys, findMissingMetricKeys, findUnansweredPrincipleKeys, updateMetric, updateNote, updatePrinciple } from "../domain/daily-entry";
+import type { DailyEntry, MetricKey, PrincipleKey } from "../domain/types";
+import { useDailyEntry } from "../app/use-daily-entry";
+import { useAppContext } from "../app/app-context";
+import { MetricGrid } from "./MetricGrid";
+import { PrincipleChecklist } from "./PrincipleChecklist";
+import { PersistedTextarea } from "./PersistedTextarea";
+import { SectionCard } from "./SectionCard";
+import { formatDateLong } from "../lib/date";
+
+interface MissingFields {
+  metricKeys: MetricKey[];
+  principleKeys: PrincipleKey[];
+  nightReflection: boolean;
+}
+
+interface PreviousDayReviewCardProps {
+  date: string;
+}
+
+export const PreviousDayReviewCard = ({ date }: PreviousDayReviewCardProps) => {
+  const { entry, loading, save } = useDailyEntry(date);
+  const { settings, saveSettings } = useAppContext();
+  const [draft, setDraft] = useState<DailyEntry | null>(null);
+  const [missing, setMissing] = useState<MissingFields | null>(null);
+
+  useEffect(() => {
+    if (draft !== null || !entry) {
+      return;
+    }
+
+    setDraft(entry);
+    setMissing({
+      metricKeys: findMissingMetricKeys(entry),
+      principleKeys: findUnansweredPrincipleKeys(entry),
+      nightReflection: entry.nightReflection.trim() === ""
+    });
+  }, [draft, entry]);
+
+  if (loading || !entry || settings.previousDayReviewDoneDate === date) {
+    return null;
+  }
+
+  if (!draft || !missing) {
+    return null;
+  }
+
+  const hasNothingMissing =
+    missing.metricKeys.length === 0 && missing.principleKeys.length === 0 && !missing.nightReflection;
+
+  if (hasNothingMissing) {
+    return null;
+  }
+
+  const handleSave = async () => {
+    const hasChanges =
+      missing.metricKeys.some((key) => draft.metrics[key] !== null) ||
+      missing.principleKeys.some((key) => draft.principleChecks[key] !== null) ||
+      draft.nightReflection.trim() !== entry.nightReflection.trim();
+
+    if (hasChanges) {
+      await save(draft);
+    }
+
+    await saveSettings({ ...settings, previousDayReviewDoneDate: date });
+  };
+
+  return (
+    <SectionCard
+      title="Finaliser hier"
+      subtitle={`${formatDateLong(date)} - complete ce qui n'a pas encore ete rempli hier soir.`}
+    >
+      {missing.metricKeys.length > 0 ? (
+        <MetricGrid
+          entry={draft}
+          keys={missing.metricKeys}
+          suggestionKeys={[...autoSuggestedMetricKeys]}
+          suggestedValues={draft.suggestedMetrics}
+          onChange={(key, value) => setDraft(updateMetric(draft, key, value))}
+        />
+      ) : null}
+
+      {missing.principleKeys.length > 0 ? (
+        <PrincipleChecklist
+          entry={draft}
+          keys={missing.principleKeys}
+          onChange={(key, value) => setDraft(updatePrinciple(draft, key, value))}
+        />
+      ) : null}
+
+      {missing.nightReflection ? (
+        <label className="stacked-field">
+          <span>Reflection du soir</span>
+          <PersistedTextarea
+            rows={4}
+            debounceMs={0}
+            savedValue={draft.nightReflection}
+            onPersist={(value) => setDraft(updateNote(draft, "nightReflection", value))}
+          />
+        </label>
+      ) : null}
+
+      <div className="form-actions">
+        <button className="button button--primary" type="button" onClick={() => void handleSave()}>
+          Enregistrer hier
+        </button>
+      </div>
+    </SectionCard>
+  );
+};

--- a/src/domain/daily-entry.test.ts
+++ b/src/domain/daily-entry.test.ts
@@ -6,6 +6,8 @@ import {
   computeDisciplineScore,
   computeTaskCompletionPercent,
   createEmptyDailyEntry,
+  findMissingMetricKeys,
+  findUnansweredPrincipleKeys,
   updateMetric,
   updateNote,
   updatePrinciple
@@ -91,5 +93,46 @@ describe("daily entry domain", () => {
 
     expect(entry.metrics.pomodoris).toBe(6);
     expect(entry.suggestedMetrics?.pomodoris).toBe(4);
+  });
+
+  it("finds missing manual metrics but ignores auto-suggested ones", () => {
+    let entry = createEmptyDailyEntry("2026-03-31");
+    entry = updateMetric(entry, "marche", 8000);
+    entry = applyDailyTaskStats(entry, {
+      date: "2026-03-31",
+      tasksAtStart: 3,
+      tasksAdded: 2,
+      tasksCompleted: 1,
+      tasksRemaining: 4
+    });
+    entry = applyDailyPomodoroStats(entry, {
+      date: "2026-03-31",
+      completedFocusSessions: 4
+    });
+
+    const missing = findMissingMetricKeys(entry);
+
+    expect(missing).toContain("course");
+    expect(missing).toContain("depenseCalorique");
+    expect(missing).toContain("qualiteSommeil");
+    expect(missing).not.toContain("marche");
+    expect(missing).not.toContain("tachesDebut");
+    expect(missing).not.toContain("tachesAjoutes");
+    expect(missing).not.toContain("tachesFin");
+    expect(missing).not.toContain("tachesRealises");
+    expect(missing).not.toContain("pomodoris");
+  });
+
+  it("finds unanswered principles but not explicit false answers", () => {
+    let entry = createEmptyDailyEntry("2026-03-31");
+    entry = updatePrinciple(entry, "priereDuSoir", false);
+    entry = updatePrinciple(entry, "retroJournalier", true);
+
+    const unanswered = findUnansweredPrincipleKeys(entry);
+
+    expect(unanswered).not.toContain("priereDuSoir");
+    expect(unanswered).not.toContain("retroJournalier");
+    expect(unanswered).toContain("attentionAMonEpouse");
+    expect(unanswered).toHaveLength(principleDefinitions.length - 2);
   });
 });

--- a/src/domain/daily-entry.ts
+++ b/src/domain/daily-entry.ts
@@ -67,7 +67,8 @@ export const defaultAppSettings = (): AppSettings => ({
   relationshipDrawChildrenActivities: [...defaultChildrenActivities],
   relationshipDrawSpouseActivities: [...defaultSpouseActivities],
   relationshipDrawChildrenProcessedDate: "",
-  relationshipDrawSpouseProcessedDate: ""
+  relationshipDrawSpouseProcessedDate: "",
+  previousDayReviewDoneDate: ""
 });
 
 export const createEmptyDailyEntry = (date: string): DailyEntry => ({
@@ -227,3 +228,13 @@ export const applyDailyPomodoroStats = (entry: DailyEntry, stats: DailyPomodoroS
 
 export const resolveMetricValue = (entry: DailyEntry, key: MetricKey): number | null =>
   entry.metrics[key] ?? entry.suggestedMetrics?.[key] ?? null;
+
+export const findMissingMetricKeys = (entry: DailyEntry): MetricKey[] =>
+  metricDefinitions
+    .filter(({ key }) => resolveMetricValue(entry, key) === null)
+    .map(({ key }) => key);
+
+export const findUnansweredPrincipleKeys = (entry: DailyEntry): PrincipleKey[] =>
+  principleDefinitions
+    .filter(({ key }) => entry.principleChecks[key] === null)
+    .map(({ key }) => key);

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -289,6 +289,7 @@ export interface AppSettings {
   relationshipDrawSpouseActivities: string[];
   relationshipDrawChildrenProcessedDate: string;
   relationshipDrawSpouseProcessedDate: string;
+  previousDayReviewDoneDate: string;
 }
 
 export interface CoachMessage {

--- a/src/pages/MorningRoutinePage.tsx
+++ b/src/pages/MorningRoutinePage.tsx
@@ -13,8 +13,10 @@ import { useDailyEntry } from "../app/use-daily-entry";
 import { EntrySummaryStrip } from "../components/EntrySummaryStrip";
 import { PersistedTextarea, type PersistedTextareaHandle } from "../components/PersistedTextarea";
 import { MetricGrid } from "../components/MetricGrid";
+import { PreviousDayReviewCard } from "../components/PreviousDayReviewCard";
 import { PrincipleChecklist } from "../components/PrincipleChecklist";
 import { SectionCard } from "../components/SectionCard";
+import { addDays } from "../lib/gtd/shared";
 import { getTodayDate, formatDateLong } from "../lib/date";
 
 export const MorningRoutinePage = () => {
@@ -41,6 +43,8 @@ export const MorningRoutinePage = () => {
       </header>
 
       <EntrySummaryStrip entry={entry} />
+
+      <PreviousDayReviewCard date={addDays(getTodayDate(), -1)} />
 
       <SectionCard title="Intention du jour" subtitle="Une phrase suffit. Cherche le ton juste, pas la perfection.">
         <label className="stacked-field">

--- a/src/styles.css
+++ b/src/styles.css
@@ -986,6 +986,11 @@ textarea {
   flex-wrap: wrap;
 }
 
+.section-stack {
+  display: grid;
+  gap: 22px;
+}
+
 .history-list {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## Summary
- Some daily metrics (steps, calories, sleep quality, etc.) can only be known the next morning, and the evening closure often gets skipped or rushed, leaving principles and the night reflection empty.
- Adds a "Finaliser hier" card at the top of the morning routine (`/routine-matin`) that shows *only* what's still missing from yesterday's entry: empty manual metrics, principles with no explicit Oui/Non answer, and the night reflection if empty.
- One "Enregistrer hier" button saves the filled-in values and sets a new `previousDayReviewDoneDate` settings flag so the card never reappears for that date; it also auto-hides once nothing is missing. Today's entry, yesterday's `status`, and `tomorrowFocus` are untouched.
- No DB migration (settings stay a JSON blob merged with defaults) and no new repository methods.

## Test plan
- [x] `npm run test` — 29 files / 124 tests pass, including the pre-existing `MorningRoutinePage.test.tsx`
- [x] `npm run build` (`tsc --noEmit && vite build`) — clean
- [x] Went through the develop-review loop (Sonnet 5 implement → Opus 5 review); approved on the first round, no fix cycles needed
- [ ] Manual check in `npm run dev`: partially fill yesterday via `/historique`, open `/routine-matin`, confirm only missing fields show, save, reload and confirm the card is gone, and confirm the values landed on yesterday's date in `/historique`

🤖 Generated with [Claude Code](https://claude.com/claude-code)