### PR TITLE
Phase 0: deterministic insight engine + AI context builder

### DIFF
--- a/docs/ai-settings-and-privacy.md
+++ b/docs/ai-settings-and-privacy.md
@@ -229,7 +229,9 @@ real repository data for today. This is a debug-only affordance for inspecting
 what each scope actually sends; it is hidden when debug mode is off. A single
 preview action resolves the RescueTime productivity pulse once (when configured)
 and reuses it across all three scopes, rather than issuing a live RescueTime
-request per scope.
+request per scope. If that resolution fails, the panel shows a non-blocking
+warning banner with the error message, and the preview itself still renders
+(with no pulse data) rather than failing outright.
 
 ## Related documentation
 

--- a/docs/ai-settings-and-privacy.md
+++ b/docs/ai-settings-and-privacy.md
@@ -19,6 +19,7 @@ Default highlights:
 | AI base URL | `https://openrouter.ai/api/v1` |
 | AI model | `moonshotai/kimi-k2.6` |
 | RescueTime API key | Empty |
+| AI payload scope | `full` |
 | Automatic backup | Enabled, 24 hours |
 | Relationship draws | Enabled |
 
@@ -213,6 +214,22 @@ Debug is always enabled in Vite development. In other builds it can be persisted
 
 Logs are not persisted to SQLite. Even so, avoid passing sensitive values to
 `logDebug`; console output can be copied or captured externally.
+
+### AI payload preview
+
+Settings has an `aiPayloadScope` control (`metrics`, `metrics_and_structure`, or
+`full`; default `full`) that governs how much detail the daily AI context
+snapshot includes — `metrics` redacts free-text notes and task/project titles,
+`metrics_and_structure` adds titles back, and `full` includes everything.
+
+When debug mode is enabled, Settings also shows a payload-preview panel with a
+button that renders the exact typed daily snapshot (`buildDailySnapshot`) that
+would be sent to the model, one collapsible block per scope, built from the
+real repository data for today. This is a debug-only affordance for inspecting
+what each scope actually sends; it is hidden when debug mode is off. A single
+preview action resolves the RescueTime productivity pulse once (when configured)
+and reuses it across all three scopes, rather than issuing a live RescueTime
+request per scope.
 
 ## Related documentation
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -5,6 +5,7 @@ the top of the table.
 
 | Date | Change | Canonical pages | Evidence |
 |---|---|---|---|
+| 2026-08-29 | Documented the Settings `aiPayloadScope` control (default `full`) and the debug-gated AI payload preview panel, including the shared RescueTime pulse fetch reused across its three scoped previews | `docs/ai-settings-and-privacy.md` | `src/domain/types.ts` (`AiPayloadScope`), `src/pages/SettingsPage.tsx`, `src/lib/ai/context/preview.ts` (`resolveProductivityPulse`) |
 | 2026-08-29 | Added a "Finaliser hier" card on `/routine-matin` that shows only yesterday's still-missing manual metrics, unanswered principles, and empty night reflection, saved via one button and hidden by `AppSettings.previousDayReviewDoneDate` | `docs/daily-routines.md` | `src/domain/daily-entry.ts` (`findMissingMetricKeys`, `findUnansweredPrincipleKeys`), `src/components/PreviousDayReviewCard.tsx`, `src/pages/MorningRoutinePage.tsx` |
 | 2026-08-13 | Added `npm run mac-install` to copy the release `Trackdidia.app` into `/Applications` | `docs/desktop-builds.md` | `scripts/mac-install.sh`, `package.json` |
 | 2026-08-12 | Weekly score: seven local axes (calories at 3800 kcal/day), optional RescueTime Goals + productivity pulse overlay on `/semaine` | `docs/reviews-and-goals.md`, `docs/ai-settings-and-privacy.md` | `src/domain/weekly-review.ts`, `src/lib/rescuetime/rescuetime-goals-service.ts`, weekly review page |

--- a/src/domain/daily-entry.ts
+++ b/src/domain/daily-entry.ts
@@ -54,6 +54,7 @@ export const defaultAppSettings = (): AppSettings => ({
   aiApiKey: "",
   aiBaseUrl: "https://openrouter.ai/api/v1",
   aiModel: "moonshotai/kimi-k2.6",
+  aiPayloadScope: "full",
   rescuetimeApiKey: "",
   autoBackupEnabled: true,
   autoBackupIntervalHours: 24,

--- a/src/domain/insights/anomalies.test.ts
+++ b/src/domain/insights/anomalies.test.ts
@@ -1,20 +1,36 @@
 import { addDays } from "../../lib/gtd/shared";
-import { createEmptyDailyEntry, updatePrinciple } from "../daily-entry";
+import { createEmptyDailyEntry, updateMetric, updatePrinciple } from "../daily-entry";
 import type { DailyEntry, PrincipleKey } from "../types";
-import { principleDefinitions } from "../definitions";
+import { morningPrincipleKeys, principleDefinitions } from "../definitions";
 import { computeAnomalyFindings } from "./anomalies";
 
-const withTruePrinciples = (date: string, keys: PrincipleKey[]): DailyEntry => {
+const withPrincipleAnswers = (date: string, answers: Partial<Record<PrincipleKey, boolean>>): DailyEntry => {
   let entry = createEmptyDailyEntry(date);
-  for (const key of keys) {
-    entry = updatePrinciple(entry, key, true);
+  for (const key of Object.keys(answers) as PrincipleKey[]) {
+    entry = updatePrinciple(entry, key, answers[key] as boolean);
   }
   return entry;
 };
 
+const withTruePrinciples = (date: string, keys: PrincipleKey[]): DailyEntry =>
+  withPrincipleAnswers(
+    date,
+    keys.reduce<Partial<Record<PrincipleKey, boolean>>>((acc, key) => ({ ...acc, [key]: true }), {})
+  );
+
+/** A fully-answered day: every principle explicitly `true` or `false` (nothing left `null`). */
+const withAllPrinciplesAnswered = (date: string, trueKeys: PrincipleKey[]): DailyEntry =>
+  withPrincipleAnswers(
+    date,
+    principleDefinitions.reduce<Partial<Record<PrincipleKey, boolean>>>(
+      (acc, { key }) => ({ ...acc, [key]: trueKeys.includes(key) }),
+      {}
+    )
+  );
+
 describe("anomalies insight module", () => {
   it("compares today's discipline to a personal baseline once the sample floor is met", () => {
-    const baseline = Array.from({ length: 10 }, (_, index) => withTruePrinciples(addDays("2026-01-01", index), []));
+    const baseline = Array.from({ length: 10 }, (_, index) => withAllPrinciplesAnswered(addDays("2026-01-01", index), []));
     const today = withTruePrinciples("2026-01-11", principleDefinitions.slice(0, 7).map((definition) => definition.key));
     const entries = [...baseline, today];
 
@@ -22,17 +38,20 @@ describe("anomalies insight module", () => {
       (item) => item.subject === "discipline" && item.scope === "today"
     );
 
+    // Today has exactly 7 principles answered, all `true`, and the other 7 still unanswered —
+    // scored over the answered subset only, that's a perfect 1.00 against a fully-answered,
+    // all-`false` baseline of 0.00.
     expect(finding).toBeDefined();
-    expect(finding?.currentValue).toBeCloseTo(0.5);
+    expect(finding?.currentValue).toBeCloseTo(1);
     expect(finding?.baselineMean).toBeCloseTo(0);
-    expect(finding?.delta).toBeCloseTo(0.5);
+    expect(finding?.delta).toBeCloseTo(1);
     expect(finding?.sampleSize).toBe(10);
     expect(finding?.severity).toBe("positive");
   });
 
   it("omits the today comparison below the minimum sample floor", () => {
-    const baseline = Array.from({ length: 9 }, (_, index) => withTruePrinciples(addDays("2026-01-01", index), []));
-    const today = withTruePrinciples("2026-01-10", []);
+    const baseline = Array.from({ length: 9 }, (_, index) => withAllPrinciplesAnswered(addDays("2026-01-01", index), []));
+    const today = withAllPrinciplesAnswered("2026-01-10", principleDefinitions.map((definition) => definition.key));
     const entries = [...baseline, today];
 
     const finding = computeAnomalyFindings(entries, "2026-01-10").find(
@@ -42,11 +61,19 @@ describe("anomalies insight module", () => {
     expect(finding).toBeUndefined();
   });
 
-  it("compares this week's average to a personal baseline of prior weeks", () => {
-    const baseline = Array.from({ length: 10 }, (_, index) => withTruePrinciples(addDays("2026-01-01", index), []));
-    const currentWeek = ["2026-01-11", "2026-01-12", "2026-01-13"].map((date) =>
-      withTruePrinciples(date, principleDefinitions.slice(0, 7).map((definition) => definition.key))
+  it("does not fire a false week watch for a genuinely in-progress week", () => {
+    const baseline = Array.from({ length: 10 }, (_, index) =>
+      withAllPrinciplesAnswered(addDays("2026-01-01", index), principleDefinitions.map((definition) => definition.key))
     );
+    // Sunday and Monday are fully-answered, perfect days. Tuesday (today) is only as far as the
+    // morning routine: the morning/anytime principles are all answered `true`, the evening ones
+    // are still `null`. This week is not a coincidental 7-of-14 boundary case — it's a real
+    // in-progress week that should read as consistent with a perfect baseline, not a collapse.
+    const currentWeek = [
+      withAllPrinciplesAnswered("2026-01-11", principleDefinitions.map((definition) => definition.key)),
+      withAllPrinciplesAnswered("2026-01-12", principleDefinitions.map((definition) => definition.key)),
+      withTruePrinciples("2026-01-13", morningPrincipleKeys)
+    ];
     const entries = [...baseline, ...currentWeek];
 
     const finding = computeAnomalyFindings(entries, "2026-01-13").find(
@@ -54,12 +81,90 @@ describe("anomalies insight module", () => {
     );
 
     expect(finding).toBeDefined();
-    expect(finding?.currentValue).toBeCloseTo(0.5);
-    expect(finding?.baselineMean).toBeCloseTo(0);
-    expect(finding?.sampleSize).toBe(10);
+    expect(finding?.currentValue).toBeCloseTo(1);
+    expect(finding?.severity).not.toBe("watch");
   });
 
   it("returns no findings for empty history", () => {
     expect(computeAnomalyFindings([])).toEqual([]);
+  });
+
+  it("does not fire a false today watch for a routinely-incomplete morning", () => {
+    const baseline = Array.from({ length: 12 }, (_, index) =>
+      withAllPrinciplesAnswered(addDays("2026-01-01", index), principleDefinitions.map((definition) => definition.key))
+    );
+    const today = createEmptyDailyEntry("2026-01-13");
+    const entries = [...baseline, today];
+
+    const finding = computeAnomalyFindings(entries, "2026-01-13").find(
+      (item) => item.subject === "discipline" && item.scope === "today"
+    );
+
+    expect(finding).toBeUndefined();
+  });
+
+  it("does not fire a false today watch when only the morning principles are answered so far", () => {
+    // Reviewer's repro: 12 perfect baseline days, then today has all 8 morning/anytime
+    // principles logged `true` and the 6 evening principles still unanswered (i.e. the user
+    // just finished their morning routine). Scoring over all 14 principles used to make this
+    // score 8/14 = 0.57 against a baseline of 1.00 and fire a false "watch"; scored over the
+    // 8 answered principles only, it's a genuine 1.00 and no anomaly fires.
+    const baseline = Array.from({ length: 12 }, (_, index) =>
+      withAllPrinciplesAnswered(addDays("2026-01-01", index), principleDefinitions.map((definition) => definition.key))
+    );
+    const today = withTruePrinciples("2026-01-13", morningPrincipleKeys);
+    const entries = [...baseline, today];
+
+    const finding = computeAnomalyFindings(entries, "2026-01-13").find(
+      (item) => item.subject === "discipline" && item.scope === "today"
+    );
+
+    expect(finding).toBeDefined();
+    expect(finding?.currentValue).toBeCloseTo(1);
+    expect(finding?.baselineMean).toBeCloseTo(1);
+    expect(finding?.severity).not.toBe("watch");
+  });
+
+  it("still fires a watch when the principles answered so far are already worse than baseline", () => {
+    const baseline = Array.from({ length: 12 }, (_, index) =>
+      withAllPrinciplesAnswered(addDays("2026-01-01", index), principleDefinitions.map((definition) => definition.key))
+    );
+    // Only the first 4 morning principles are answered so far, and 3 of the 4 are `false` — a
+    // real collapse among the principles actually answered, not just an incomplete day.
+    const today = withPrincipleAnswers("2026-01-13", {
+      [morningPrincipleKeys[0]]: false,
+      [morningPrincipleKeys[1]]: false,
+      [morningPrincipleKeys[2]]: false,
+      [morningPrincipleKeys[3]]: true
+    });
+    const entries = [...baseline, today];
+
+    const finding = computeAnomalyFindings(entries, "2026-01-13").find(
+      (item) => item.subject === "discipline" && item.scope === "today"
+    );
+
+    expect(finding).toBeDefined();
+    expect(finding?.currentValue).toBeCloseTo(0.25);
+    expect(finding?.severity).toBe("watch");
+  });
+
+  it("flags a real metric anomaly regardless of principle-answering state", () => {
+    const baseline = Array.from({ length: 12 }, (_, index) =>
+      updateMetric(createEmptyDailyEntry(addDays("2026-01-01", index)), "course", 5)
+    );
+    // Nothing has been answered for any principle today, which used to suppress every subject
+    // (including unrelated metrics) via the principle-completeness gate. The `course` metric was
+    // fully and validly logged at 0, so it should fire on its own merits.
+    const today = updateMetric(createEmptyDailyEntry("2026-01-13"), "course", 0);
+    const entries = [...baseline, today];
+
+    const finding = computeAnomalyFindings(entries, "2026-01-13").find(
+      (item) => item.subject === "course" && item.scope === "today"
+    );
+
+    expect(finding).toBeDefined();
+    expect(finding?.currentValue).toBeCloseTo(0);
+    expect(finding?.baselineMean).toBeCloseTo(5);
+    expect(finding?.severity).toBe("watch");
   });
 });

--- a/src/domain/insights/anomalies.test.ts
+++ b/src/domain/insights/anomalies.test.ts
@@ -1,0 +1,65 @@
+import { addDays } from "../../lib/gtd/shared";
+import { createEmptyDailyEntry, updatePrinciple } from "../daily-entry";
+import type { DailyEntry, PrincipleKey } from "../types";
+import { principleDefinitions } from "../definitions";
+import { computeAnomalyFindings } from "./anomalies";
+
+const withTruePrinciples = (date: string, keys: PrincipleKey[]): DailyEntry => {
+  let entry = createEmptyDailyEntry(date);
+  for (const key of keys) {
+    entry = updatePrinciple(entry, key, true);
+  }
+  return entry;
+};
+
+describe("anomalies insight module", () => {
+  it("compares today's discipline to a personal baseline once the sample floor is met", () => {
+    const baseline = Array.from({ length: 10 }, (_, index) => withTruePrinciples(addDays("2026-01-01", index), []));
+    const today = withTruePrinciples("2026-01-11", principleDefinitions.slice(0, 7).map((definition) => definition.key));
+    const entries = [...baseline, today];
+
+    const finding = computeAnomalyFindings(entries, "2026-01-11").find(
+      (item) => item.subject === "discipline" && item.scope === "today"
+    );
+
+    expect(finding).toBeDefined();
+    expect(finding?.currentValue).toBeCloseTo(0.5);
+    expect(finding?.baselineMean).toBeCloseTo(0);
+    expect(finding?.delta).toBeCloseTo(0.5);
+    expect(finding?.sampleSize).toBe(10);
+    expect(finding?.severity).toBe("positive");
+  });
+
+  it("omits the today comparison below the minimum sample floor", () => {
+    const baseline = Array.from({ length: 9 }, (_, index) => withTruePrinciples(addDays("2026-01-01", index), []));
+    const today = withTruePrinciples("2026-01-10", []);
+    const entries = [...baseline, today];
+
+    const finding = computeAnomalyFindings(entries, "2026-01-10").find(
+      (item) => item.subject === "discipline" && item.scope === "today"
+    );
+
+    expect(finding).toBeUndefined();
+  });
+
+  it("compares this week's average to a personal baseline of prior weeks", () => {
+    const baseline = Array.from({ length: 10 }, (_, index) => withTruePrinciples(addDays("2026-01-01", index), []));
+    const currentWeek = ["2026-01-11", "2026-01-12", "2026-01-13"].map((date) =>
+      withTruePrinciples(date, principleDefinitions.slice(0, 7).map((definition) => definition.key))
+    );
+    const entries = [...baseline, ...currentWeek];
+
+    const finding = computeAnomalyFindings(entries, "2026-01-13").find(
+      (item) => item.subject === "discipline" && item.scope === "week"
+    );
+
+    expect(finding).toBeDefined();
+    expect(finding?.currentValue).toBeCloseTo(0.5);
+    expect(finding?.baselineMean).toBeCloseTo(0);
+    expect(finding?.sampleSize).toBe(10);
+  });
+
+  it("returns no findings for empty history", () => {
+    expect(computeAnomalyFindings([])).toEqual([]);
+  });
+});

--- a/src/domain/insights/anomalies.ts
+++ b/src/domain/insights/anomalies.ts
@@ -1,0 +1,127 @@
+import { getWeekStartSunday } from "../../lib/gtd/shared";
+import { computeDisciplineScore, resolveMetricValue } from "../daily-entry";
+import { metricDefinitions } from "../definitions";
+import type { DailyEntry, MetricKey } from "../types";
+import { MIN_SAMPLE_DAYS } from "./constants";
+import { average, buildEvidenceWindow, latestEntryDate, sortEntriesByDate } from "./shared";
+import type { Finding } from "./types";
+
+export type AnomalySubject = MetricKey | "discipline";
+export type AnomalyScope = "today" | "week";
+
+export interface AnomalyFinding extends Finding {
+  subject: AnomalySubject;
+  scope: AnomalyScope;
+  currentValue: number;
+  baselineMean: number;
+  delta: number;
+}
+
+const resolveSubjectValue = (entry: DailyEntry, subject: AnomalySubject): number | null =>
+  subject === "discipline" ? computeDisciplineScore(entry) : resolveMetricValue(entry, subject);
+
+const anomalySeverity = (delta: number, baselineMean: number): AnomalyFinding["severity"] => {
+  const denominator = Math.abs(baselineMean) > 0.0001 ? Math.abs(baselineMean) : 1;
+  const ratio = delta / denominator;
+
+  if (ratio <= -0.25) {
+    return "watch";
+  }
+  if (ratio >= 0.25) {
+    return "positive";
+  }
+  return "info";
+};
+
+const buildFinding = (
+  subject: AnomalySubject,
+  scope: AnomalyScope,
+  referenceDate: string,
+  currentValue: number,
+  baselineValues: number[],
+  baselineFrom: string
+): AnomalyFinding | null => {
+  if (baselineValues.length < MIN_SAMPLE_DAYS) {
+    return null;
+  }
+
+  const baselineMean = average(baselineValues);
+  const delta = currentValue - baselineMean;
+
+  return {
+    id: `anomaly:${scope}:${subject}:${referenceDate}`,
+    severity: anomalySeverity(delta, baselineMean),
+    evidenceWindow: buildEvidenceWindow(baselineFrom, referenceDate),
+    sampleSize: baselineValues.length,
+    value: currentValue,
+    label: `${scope === "today" ? "Aujourd'hui" : "Cette semaine"}, ${subject}: ${currentValue.toFixed(2)} vs une base personnelle de ${baselineMean.toFixed(2)} (n=${baselineValues.length}).`,
+    subject,
+    scope,
+    currentValue,
+    baselineMean,
+    delta
+  };
+};
+
+/**
+ * Today and this-week values versus a personal baseline, gated by a minimum sample floor
+ * (spec `ai-integration-v2.md` §3). Below `MIN_SAMPLE_DAYS` of baseline evidence, the
+ * comparison is omitted rather than reported with low confidence.
+ */
+export const computeAnomalyFindings = (entries: DailyEntry[], referenceDate?: string): AnomalyFinding[] => {
+  const ordered = sortEntriesByDate(entries);
+  const reference = referenceDate ?? latestEntryDate(ordered);
+
+  if (!reference) {
+    return [];
+  }
+
+  const subjects: AnomalySubject[] = ["discipline", ...metricDefinitions.map(({ key }) => key)];
+  const findings: AnomalyFinding[] = [];
+
+  const todayEntry = ordered.find((entry) => entry.date === reference);
+  const beforeToday = ordered.filter((entry) => entry.date < reference);
+
+  const weekStart = getWeekStartSunday(reference);
+  const currentWeekEntries = ordered.filter((entry) => entry.date >= weekStart && entry.date <= reference);
+  const beforeWeek = ordered.filter((entry) => entry.date < weekStart);
+
+  for (const subject of subjects) {
+    if (todayEntry) {
+      const currentValue = resolveSubjectValue(todayEntry, subject);
+      const baselineValues = beforeToday
+        .map((entry) => resolveSubjectValue(entry, subject))
+        .filter((value): value is number => value !== null);
+
+      if (currentValue !== null && beforeToday.length > 0) {
+        const finding = buildFinding(subject, "today", reference, currentValue, baselineValues, beforeToday[0].date);
+        if (finding) {
+          findings.push(finding);
+        }
+      }
+    }
+
+    const currentWeekValues = currentWeekEntries
+      .map((entry) => resolveSubjectValue(entry, subject))
+      .filter((value): value is number => value !== null);
+    const baselineWeekValues = beforeWeek
+      .map((entry) => resolveSubjectValue(entry, subject))
+      .filter((value): value is number => value !== null);
+
+    if (currentWeekValues.length > 0 && beforeWeek.length > 0) {
+      const finding = buildFinding(
+        subject,
+        "week",
+        reference,
+        average(currentWeekValues),
+        baselineWeekValues,
+        beforeWeek[0].date
+      );
+      if (finding) {
+        findings.push(finding);
+      }
+    }
+  }
+
+  return findings;
+};

--- a/src/domain/insights/anomalies.ts
+++ b/src/domain/insights/anomalies.ts
@@ -1,6 +1,6 @@
 import { getWeekStartSunday } from "../../lib/gtd/shared";
-import { computeDisciplineScore, resolveMetricValue } from "../daily-entry";
-import { metricDefinitions } from "../definitions";
+import { resolveMetricValue } from "../daily-entry";
+import { metricDefinitions, principleDefinitions } from "../definitions";
 import type { DailyEntry, MetricKey } from "../types";
 import { MIN_SAMPLE_DAYS } from "./constants";
 import { average, buildEvidenceWindow, latestEntryDate, sortEntriesByDate } from "./shared";
@@ -17,8 +17,30 @@ export interface AnomalyFinding extends Finding {
   delta: number;
 }
 
+/**
+ * Discipline score for one day, computed over only the principles that have actually been
+ * answered (`true` or `false`) rather than over every principle (contrast with the
+ * all-principles denominator `computeDisciplineScore` uses elsewhere, e.g. for the day's
+ * completion percentage). An in-progress day — say, this morning, with only the
+ * morning/anytime principles logged so far — otherwise looks identical to a day where every
+ * still-unanswered principle was explicitly failed, and a partially-answered day is then
+ * structurally guaranteed to look like a collapse next to a baseline of fully-answered days,
+ * no matter how the "is this day far enough along" threshold is set. Scoring over the
+ * answered subset means a perfect partial day still scores `1.00`, and a day with nothing
+ * answered yet naturally drops out (`null`, filtered by callers) instead of scoring `0`.
+ */
+const computeAnsweredDisciplineScore = (entry: DailyEntry): number | null => {
+  const answered = principleDefinitions.filter(({ key }) => entry.principleChecks[key] !== null);
+  if (answered.length === 0) {
+    return null;
+  }
+
+  const trueCount = answered.filter(({ key }) => entry.principleChecks[key] === true).length;
+  return trueCount / answered.length;
+};
+
 const resolveSubjectValue = (entry: DailyEntry, subject: AnomalySubject): number | null =>
-  subject === "discipline" ? computeDisciplineScore(entry) : resolveMetricValue(entry, subject);
+  subject === "discipline" ? computeAnsweredDisciplineScore(entry) : resolveMetricValue(entry, subject);
 
 const anomalySeverity = (delta: number, baselineMean: number): AnomalyFinding["severity"] => {
   const denominator = Math.abs(baselineMean) > 0.0001 ? Math.abs(baselineMean) : 1;

--- a/src/domain/insights/constants.ts
+++ b/src/domain/insights/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * Named tuning constants for the insight engine (spec `ai-integration-v2.md` §3, §14.5).
+ * `MIN_SAMPLE_DAYS` is a guess per the spec's open question #5 and is meant to be
+ * revisited once phase 0 can report real history sizes.
+ */
+
+/** Minimum number of days of evidence required before a correlation or anomaly is reported. */
+export const MIN_SAMPLE_DAYS = 10;
+
+/** A next action is "stale" once it has gone untouched for more than this many days. */
+export const STALE_NEXT_ACTION_DAYS = 7;
+
+/** A waiting-for item is "aging" once it has gone untouched for more than this many days. */
+export const AGING_WAITING_FOR_DAYS = 14;
+
+/** Trailing window used for the short-horizon trend average. */
+export const TREND_SHORT_WINDOW_DAYS = 7;
+
+/** Trailing window used for the long-horizon trend average and most rate calculations. */
+export const TREND_LONG_WINDOW_DAYS = 28;
+
+/** Daily completed-focus-session target used to normalize focus load (mirrors the weekly `pomodoroTarget` of 56/7). */
+export const POMODORO_DAILY_TARGET_SESSIONS = 8;

--- a/src/domain/insights/correlations.test.ts
+++ b/src/domain/insights/correlations.test.ts
@@ -1,0 +1,62 @@
+import { addDays } from "../../lib/gtd/shared";
+import { createEmptyDailyEntry, updatePrinciple } from "../daily-entry";
+import type { DailyEntry } from "../types";
+import { computeCorrelationFindings } from "./correlations";
+
+const buildEntry = (date: string, isTrue: boolean): DailyEntry => {
+  let entry = createEmptyDailyEntry(date);
+  entry = updatePrinciple(entry, "priereDuMatin", isTrue);
+
+  if (isTrue) {
+    entry = updatePrinciple(entry, "oxytocineDuMatin", true);
+    entry = updatePrinciple(entry, "ecriture", true);
+    entry = updatePrinciple(entry, "apprentissage", true);
+    entry = updatePrinciple(entry, "managedSolitude", true);
+  }
+
+  return entry;
+};
+
+describe("correlations insight module", () => {
+  it("reports the discipline difference between true and false days once the sample floor is met", () => {
+    const trueDays = Array.from({ length: 6 }, (_, index) => buildEntry(addDays("2026-01-01", index), true));
+    const falseDays = Array.from({ length: 6 }, (_, index) => buildEntry(addDays("2026-01-07", index), false));
+    const entries = [...trueDays, ...falseDays];
+
+    const finding = computeCorrelationFindings(entries).find((item) => item.principleKey === "priereDuMatin");
+
+    expect(finding).toBeDefined();
+    expect(finding?.sampleSize).toBe(12);
+    expect(finding?.sampleSizeTrue).toBe(6);
+    expect(finding?.sampleSizeFalse).toBe(6);
+    expect(finding?.meanDisciplineWhenTrue).toBeCloseTo(5 / 14);
+    expect(finding?.meanDisciplineWhenFalse).toBeCloseTo(0);
+    expect(finding?.diff).toBeCloseTo(5 / 14);
+    expect(finding?.value).toBeCloseTo(5 / 14);
+    expect(finding?.severity).toBe("positive");
+    expect(finding?.label).toContain("associee");
+    expect(finding?.label.toLowerCase()).not.toContain("cause");
+  });
+
+  it("omits the finding below the minimum sample floor", () => {
+    const trueDays = Array.from({ length: 4 }, (_, index) => buildEntry(addDays("2026-01-01", index), true));
+    const falseDays = Array.from({ length: 4 }, (_, index) => buildEntry(addDays("2026-01-05", index), false));
+    const entries = [...trueDays, ...falseDays];
+
+    const finding = computeCorrelationFindings(entries).find((item) => item.principleKey === "priereDuMatin");
+
+    expect(finding).toBeUndefined();
+  });
+
+  it("omits the finding when one side of the comparison has no data", () => {
+    const entries = Array.from({ length: 12 }, (_, index) => buildEntry(addDays("2026-01-01", index), true));
+
+    const finding = computeCorrelationFindings(entries).find((item) => item.principleKey === "priereDuMatin");
+
+    expect(finding).toBeUndefined();
+  });
+
+  it("returns no findings for empty history", () => {
+    expect(computeCorrelationFindings([])).toEqual([]);
+  });
+});

--- a/src/domain/insights/correlations.ts
+++ b/src/domain/insights/correlations.ts
@@ -1,0 +1,59 @@
+import { computeDisciplineScore } from "../daily-entry";
+import { principleDefinitions } from "../definitions";
+import type { DailyEntry, PrincipleKey } from "../types";
+import { MIN_SAMPLE_DAYS } from "./constants";
+import { average, buildEvidenceWindow, sortEntriesByDate } from "./shared";
+import type { Finding } from "./types";
+
+export interface CorrelationFinding extends Finding {
+  principleKey: PrincipleKey;
+  meanDisciplineWhenTrue: number;
+  meanDisciplineWhenFalse: number;
+  sampleSizeTrue: number;
+  sampleSizeFalse: number;
+  /** `meanDisciplineWhenTrue - meanDisciplineWhenFalse`. Positive means higher discipline on `true` days. */
+  diff: number;
+}
+
+/**
+ * Difference of mean discipline on days a principle is `true` vs `false`, with sample size
+ * (spec `ai-integration-v2.md` §3). Below `MIN_SAMPLE_DAYS` total qualifying days, or when
+ * one side of the comparison has no data, the finding is omitted rather than weakened —
+ * this is an observation, never a causal claim.
+ */
+export const computeCorrelationFindings = (entries: DailyEntry[]): CorrelationFinding[] => {
+  const ordered = sortEntriesByDate(entries);
+  const findings: CorrelationFinding[] = [];
+
+  for (const { key } of principleDefinitions) {
+    const trueEntries = ordered.filter((entry) => entry.principleChecks[key] === true);
+    const falseEntries = ordered.filter((entry) => entry.principleChecks[key] === false);
+    const sampleSize = trueEntries.length + falseEntries.length;
+
+    if (sampleSize < MIN_SAMPLE_DAYS || trueEntries.length === 0 || falseEntries.length === 0) {
+      continue;
+    }
+
+    const meanDisciplineWhenTrue = average(trueEntries.map((entry) => computeDisciplineScore(entry)));
+    const meanDisciplineWhenFalse = average(falseEntries.map((entry) => computeDisciplineScore(entry)));
+    const diff = meanDisciplineWhenTrue - meanDisciplineWhenFalse;
+    const qualifyingDates = [...trueEntries, ...falseEntries].map((entry) => entry.date).sort();
+
+    findings.push({
+      id: `correlation:${key}`,
+      severity: diff >= 0.1 ? "positive" : diff <= -0.1 ? "watch" : "info",
+      evidenceWindow: buildEvidenceWindow(qualifyingDates[0], qualifyingDates[qualifyingDates.length - 1]),
+      sampleSize,
+      value: diff,
+      label: `Discipline moyenne associee aux jours avec ${key}: ${Math.round(meanDisciplineWhenTrue * 100)}% (vs ${Math.round(meanDisciplineWhenFalse * 100)}% sans, n=${sampleSize}).`,
+      principleKey: key,
+      meanDisciplineWhenTrue,
+      meanDisciplineWhenFalse,
+      sampleSizeTrue: trueEntries.length,
+      sampleSizeFalse: falseEntries.length,
+      diff
+    });
+  }
+
+  return findings;
+};

--- a/src/domain/insights/focus.test.ts
+++ b/src/domain/insights/focus.test.ts
@@ -1,0 +1,70 @@
+import type { PomodoroTaskSummary } from "../types";
+import { computeFocusFindings } from "./focus";
+
+const now = "2026-02-01T12:00:00.000Z";
+
+const summaries: PomodoroTaskSummary[] = [
+  { taskId: "t1", taskTitle: "A", totalSeconds: 1800, sessionCount: 3 },
+  { taskId: "t2", taskTitle: "B", totalSeconds: 600, sessionCount: 1 }
+];
+
+describe("focus insight module", () => {
+  it("reports pomodoro totals", () => {
+    const findings = computeFocusFindings(summaries, 4, now);
+    const finding = findings.find((item) => item.kind === "focus_totals");
+
+    expect(finding?.value).toBe(4);
+    expect(finding?.sampleSize).toBe(4);
+  });
+
+  it("reports task concentration as the share of focus time in the top task", () => {
+    const findings = computeFocusFindings(summaries, 4, now);
+    const finding = findings.find((item) => item.kind === "task_concentration");
+
+    expect(finding?.value).toBeCloseTo(0.75);
+    expect(finding?.severity).toBe("positive");
+  });
+
+  it("omits task concentration when there is no focus time at all", () => {
+    const findings = computeFocusFindings([], 0, now);
+
+    expect(findings.find((item) => item.kind === "task_concentration")).toBeUndefined();
+  });
+
+  it("classifies focus/pulse alignment as aligned_high when both are strong", () => {
+    const findings = computeFocusFindings(summaries, 5, now, 80);
+    const finding = findings.find((item) => item.kind === "focus_pulse_alignment");
+
+    expect(finding?.alignment).toBe("aligned_high");
+    expect(finding?.severity).toBe("positive");
+  });
+
+  it("classifies focus/pulse alignment as aligned_low when both are weak", () => {
+    const findings = computeFocusFindings(summaries, 1, now, 10);
+    const finding = findings.find((item) => item.kind === "focus_pulse_alignment");
+
+    expect(finding?.alignment).toBe("aligned_low");
+    expect(finding?.severity).toBe("watch");
+  });
+
+  it("classifies a divergence between focus and RescueTime pulse", () => {
+    const findings = computeFocusFindings(summaries, 8, now, 10);
+    const finding = findings.find((item) => item.kind === "focus_pulse_alignment");
+
+    expect(finding?.alignment).toBe("focus_high_pulse_low");
+  });
+
+  it("omits the alignment finding when RescueTime is not configured", () => {
+    const findings = computeFocusFindings(summaries, 4, now, null);
+
+    expect(findings.find((item) => item.kind === "focus_pulse_alignment")).toBeUndefined();
+  });
+
+  it("labels the pulse-alignment finding as an approximate, mismatched-period comparison", () => {
+    const findings = computeFocusFindings(summaries, 5, now, 80);
+    const finding = findings.find((item) => item.kind === "focus_pulse_alignment");
+
+    expect(finding?.label).toContain("periodes differentes");
+    expect(finding?.label).toContain("semaine en cours");
+  });
+});

--- a/src/domain/insights/focus.ts
+++ b/src/domain/insights/focus.ts
@@ -1,0 +1,115 @@
+import { toLocalDateString } from "../../lib/gtd/shared";
+import type { PomodoroTaskSummary } from "../types";
+import { POMODORO_DAILY_TARGET_SESSIONS } from "./constants";
+import { buildEvidenceWindow } from "./shared";
+import type { Finding } from "./types";
+
+export type FocusFindingKind = "focus_totals" | "task_concentration" | "focus_pulse_alignment";
+export type FocusPulseAlignment = "aligned_high" | "aligned_low" | "focus_high_pulse_low" | "pulse_high_focus_low";
+
+export interface FocusFinding extends Finding {
+  kind: FocusFindingKind;
+  alignment?: FocusPulseAlignment;
+}
+
+const buildFinding = (
+  kind: FocusFindingKind,
+  now: string,
+  value: number,
+  sampleSize: number,
+  label: string,
+  severity: Finding["severity"] = "info",
+  alignment?: FocusPulseAlignment
+): FocusFinding => {
+  const nowDate = toLocalDateString(now);
+  return {
+    id: `focus:${kind}:${nowDate}`,
+    severity,
+    evidenceWindow: buildEvidenceWindow(nowDate, nowDate),
+    sampleSize,
+    value,
+    label,
+    kind,
+    alignment
+  };
+};
+
+/**
+ * Pomodoro totals, task concentration and focus-versus-RescueTime-pulse alignment
+ * (spec `ai-integration-v2.md` §3). `productivityPulseWeekToDate` is the already-fetched
+ * RescueTime pulse (0-100) for the current Sunday-to-date week, or `null`/`undefined` when
+ * RescueTime is not configured — in that case the alignment finding is omitted, not guessed.
+ *
+ * Phase 0 has no same-period daily RescueTime pulse to compare against `completedFocusSessionCount`
+ * (a daily count), so `focus_pulse_alignment` is an approximate, mismatched-period comparison
+ * (today's focus load vs. the week-to-date pulse) — the label says so explicitly rather than
+ * implying the two figures cover the same period.
+ */
+export const computeFocusFindings = (
+  taskSummaries: PomodoroTaskSummary[],
+  completedFocusSessionCount: number,
+  now: string,
+  productivityPulseWeekToDate?: number | null
+): FocusFinding[] => {
+  const findings: FocusFinding[] = [];
+  const totalSeconds = taskSummaries.reduce((sum, summary) => sum + summary.totalSeconds, 0);
+  const totalMinutes = Math.round(totalSeconds / 60);
+
+  findings.push(
+    buildFinding(
+      "focus_totals",
+      now,
+      completedFocusSessionCount,
+      completedFocusSessionCount,
+      `${completedFocusSessionCount} session(s) de focus completee(s), ${totalMinutes} minute(s) au total.`
+    )
+  );
+
+  if (totalSeconds > 0) {
+    const topTaskSeconds = Math.max(...taskSummaries.map((summary) => summary.totalSeconds));
+    const concentration = topTaskSeconds / totalSeconds;
+    findings.push(
+      buildFinding(
+        "task_concentration",
+        now,
+        concentration,
+        taskSummaries.length,
+        `${Math.round(concentration * 100)}% du temps de focus concentre sur une seule tache.`,
+        concentration >= 0.6 ? "positive" : "info"
+      )
+    );
+  }
+
+  if (productivityPulseWeekToDate !== null && productivityPulseWeekToDate !== undefined) {
+    const focusRatio = Math.min(1, completedFocusSessionCount / POMODORO_DAILY_TARGET_SESSIONS);
+    const pulseRatio = productivityPulseWeekToDate / 100;
+    const diff = focusRatio - pulseRatio;
+    const bothHigh = focusRatio >= 0.5 && pulseRatio >= 0.5;
+    const bothLow = focusRatio < 0.5 && pulseRatio < 0.5;
+
+    let alignment: FocusPulseAlignment;
+    if (bothHigh) {
+      alignment = "aligned_high";
+    } else if (bothLow) {
+      alignment = "aligned_low";
+    } else if (diff > 0) {
+      alignment = "focus_high_pulse_low";
+    } else {
+      alignment = "pulse_high_focus_low";
+    }
+
+    findings.push(
+      buildFinding(
+        "focus_pulse_alignment",
+        now,
+        diff,
+        completedFocusSessionCount,
+        `Sessions focus du jour comparees (approximation, periodes differentes) au pulse RescueTime de la semaine en cours a ce jour (${Math.round(productivityPulseWeekToDate)}/100) (alignement: ${alignment}).`,
+        bothHigh ? "positive" : bothLow ? "watch" : "info",
+        alignment
+      )
+    );
+  }
+
+  return findings;
+};

--- a/src/domain/insights/gtd-health.test.ts
+++ b/src/domain/insights/gtd-health.test.ts
@@ -1,0 +1,134 @@
+import type { Project, Task } from "../types";
+import { computeGtdHealthFindings } from "./gtd-health";
+
+const now = "2026-02-01T12:00:00.000Z";
+
+const buildTask = (overrides: Partial<Task>): Task => ({
+  id: overrides.id ?? "task:default",
+  title: "Task",
+  notes: "",
+  status: "active",
+  bucket: "inbox",
+  contextIds: [],
+  projectId: null,
+  parentTaskId: null,
+  scheduledFor: null,
+  deadline: null,
+  recurringTemplateId: null,
+  recurrenceDueDate: null,
+  isRecurringInstance: false,
+  completedAt: null,
+  recurrenceGroupId: null,
+  pendingPastRecurrences: 0,
+  source: "manual",
+  sourceExternalId: null,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides
+});
+
+const buildProject = (overrides: Partial<Project>): Project => ({
+  id: overrides.id ?? "project:default",
+  title: "Project",
+  status: "active",
+  statusChangedAt: now,
+  notes: "",
+  contextIds: [],
+  source: "manual",
+  sourceExternalId: null,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides
+});
+
+const findKind = (
+  findings: ReturnType<typeof computeGtdHealthFindings>,
+  kind: ReturnType<typeof computeGtdHealthFindings>[number]["kind"]
+) => findings.find((finding) => finding.kind === kind);
+
+describe("gtd-health insight module", () => {
+  it("counts the inbox backlog", () => {
+    const tasks = [buildTask({ id: "t1", bucket: "inbox" }), buildTask({ id: "t2", bucket: "next_action" })];
+
+    const finding = findKind(computeGtdHealthFindings(tasks, [], now), "inbox_backlog");
+
+    expect(finding?.value).toBe(1);
+    expect(finding?.sampleSize).toBe(2);
+    expect(finding?.taskIds).toEqual(["t1"]);
+  });
+
+  it("finds active projects without an active next action", () => {
+    const projects = [buildProject({ id: "p1" }), buildProject({ id: "p2" })];
+    const tasks = [buildTask({ id: "t1", bucket: "next_action", projectId: "p2" })];
+
+    const finding = findKind(computeGtdHealthFindings(tasks, projects, now), "projects_without_next_action");
+
+    expect(finding?.value).toBe(1);
+    expect(finding?.projectIds).toEqual(["p1"]);
+  });
+
+  it("flags next actions untouched for more than the stale threshold", () => {
+    const tasks = [
+      buildTask({ id: "stale", bucket: "next_action", updatedAt: "2026-01-22T12:00:00.000Z" }),
+      buildTask({ id: "fresh", bucket: "next_action", updatedAt: now })
+    ];
+
+    const finding = findKind(computeGtdHealthFindings(tasks, [], now), "stale_next_actions");
+
+    expect(finding?.value).toBe(1);
+    expect(finding?.sampleSize).toBe(2);
+    expect(finding?.taskIds).toEqual(["stale"]);
+  });
+
+  it("flags waiting-for items aging beyond the threshold", () => {
+    const tasks = [
+      buildTask({ id: "aging", bucket: "waiting_for", updatedAt: "2026-01-12T12:00:00.000Z" }),
+      buildTask({ id: "recent", bucket: "waiting_for", updatedAt: "2026-01-27T12:00:00.000Z" })
+    ];
+
+    const finding = findKind(computeGtdHealthFindings(tasks, [], now), "aging_waiting_for");
+
+    expect(finding?.value).toBe(1);
+    expect(finding?.taskIds).toEqual(["aging"]);
+  });
+
+  it("flags overdue deadlines", () => {
+    const tasks = [
+      buildTask({ id: "overdue", bucket: "next_action", deadline: "2026-01-27" }),
+      buildTask({ id: "future", bucket: "next_action", deadline: "2026-02-06" })
+    ];
+
+    const finding = findKind(computeGtdHealthFindings(tasks, [], now), "overdue_deadlines");
+
+    expect(finding?.value).toBe(1);
+    expect(finding?.taskIds).toEqual(["overdue"]);
+  });
+
+  it("computes the scheduled-vs-completed ratio over the trailing window", () => {
+    const tasks = [
+      buildTask({ id: "scheduled", bucket: "scheduled" }),
+      buildTask({
+        id: "completed-recent",
+        status: "completed",
+        completedAt: "2026-01-20T12:00:00.000Z"
+      }),
+      buildTask({
+        id: "completed-old",
+        status: "completed",
+        completedAt: "2025-12-01T12:00:00.000Z"
+      })
+    ];
+
+    const finding = findKind(computeGtdHealthFindings(tasks, [], now), "scheduled_vs_completed_ratio");
+
+    expect(finding?.value).toBeCloseTo(1);
+    expect(finding?.taskIds).toEqual(expect.arrayContaining(["scheduled", "completed-recent"]));
+    expect(finding?.taskIds).not.toContain("completed-old");
+  });
+
+  it("handles empty task and project lists without throwing", () => {
+    const findings = computeGtdHealthFindings([], [], now);
+
+    expect(findings.every((finding) => finding.value === 0)).toBe(true);
+  });
+});

--- a/src/domain/insights/gtd-health.ts
+++ b/src/domain/insights/gtd-health.ts
@@ -1,0 +1,155 @@
+import { addDays, toLocalDateString } from "../../lib/gtd/shared";
+import type { Project, Task } from "../types";
+import { AGING_WAITING_FOR_DAYS, STALE_NEXT_ACTION_DAYS, TREND_LONG_WINDOW_DAYS } from "./constants";
+import { buildEvidenceWindow, daysBetweenDates } from "./shared";
+import type { Finding } from "./types";
+
+export type GtdHealthFindingKind =
+  | "inbox_backlog"
+  | "projects_without_next_action"
+  | "stale_next_actions"
+  | "aging_waiting_for"
+  | "overdue_deadlines"
+  | "scheduled_vs_completed_ratio";
+
+export interface GtdHealthFinding extends Finding {
+  kind: GtdHealthFindingKind;
+  taskIds: string[];
+  projectIds: string[];
+}
+
+const buildFinding = (
+  kind: GtdHealthFindingKind,
+  now: string,
+  value: number,
+  /** Size of the population this finding was evaluated over (not just the matching items). */
+  sampleSize: number,
+  label: string,
+  options: { taskIds?: string[]; projectIds?: string[]; severity?: Finding["severity"] } = {}
+): GtdHealthFinding => {
+  const nowDate = toLocalDateString(now);
+  return {
+    id: `gtd_health:${kind}:${nowDate}`,
+    severity: options.severity ?? (value > 0 ? "watch" : "info"),
+    evidenceWindow: buildEvidenceWindow(nowDate, nowDate),
+    sampleSize,
+    value,
+    label,
+    kind,
+    taskIds: options.taskIds ?? [],
+    projectIds: options.projectIds ?? []
+  };
+};
+
+/**
+ * GTD workspace health (spec `ai-integration-v2.md` §3): inbox backlog, projects with no
+ * next action, next actions untouched for too long, aging waiting-for items, overdue
+ * deadlines, and the scheduled-vs-completed ratio. `now` is an ISO instant so callers stay
+ * in control of "current time" for deterministic tests.
+ */
+export const computeGtdHealthFindings = (tasks: Task[], projects: Project[], now: string): GtdHealthFinding[] => {
+  const nowDate = toLocalDateString(now);
+  const findings: GtdHealthFinding[] = [];
+
+  const activeTasks = tasks.filter((task) => task.status === "active");
+
+  const inboxTasks = activeTasks.filter((task) => task.bucket === "inbox");
+  findings.push(
+    buildFinding(
+      "inbox_backlog",
+      now,
+      inboxTasks.length,
+      activeTasks.length,
+      `${inboxTasks.length} element(s) en attente de clarification dans l'inbox.`,
+      { taskIds: inboxTasks.map((task) => task.id) }
+    )
+  );
+
+  const activeNextActionProjectIds = new Set(
+    activeTasks
+      .filter((task) => task.bucket === "next_action" && task.projectId)
+      .map((task) => task.projectId as string)
+  );
+  const activeProjects = projects.filter((project) => project.status === "active");
+  const projectsWithoutNextAction = activeProjects.filter(
+    (project) => !activeNextActionProjectIds.has(project.id)
+  );
+  findings.push(
+    buildFinding(
+      "projects_without_next_action",
+      now,
+      projectsWithoutNextAction.length,
+      activeProjects.length,
+      `${projectsWithoutNextAction.length} projet(s) actif(s) sans next action associee.`,
+      { projectIds: projectsWithoutNextAction.map((project) => project.id) }
+    )
+  );
+
+  const nextActions = activeTasks.filter((task) => task.bucket === "next_action");
+  const staleNextActions = nextActions.filter(
+    (task) => daysBetweenDates(toLocalDateString(task.updatedAt), nowDate) > STALE_NEXT_ACTION_DAYS
+  );
+  findings.push(
+    buildFinding(
+      "stale_next_actions",
+      now,
+      staleNextActions.length,
+      nextActions.length,
+      `${staleNextActions.length} next action(s) non touchee(s) depuis plus de ${STALE_NEXT_ACTION_DAYS} jours.`,
+      { taskIds: staleNextActions.map((task) => task.id) }
+    )
+  );
+
+  const waitingForTasks = activeTasks.filter((task) => task.bucket === "waiting_for");
+  const agingWaitingFor = waitingForTasks.filter(
+    (task) => daysBetweenDates(toLocalDateString(task.updatedAt), nowDate) > AGING_WAITING_FOR_DAYS
+  );
+  findings.push(
+    buildFinding(
+      "aging_waiting_for",
+      now,
+      agingWaitingFor.length,
+      waitingForTasks.length,
+      `${agingWaitingFor.length} attente(s) non relancee(s) depuis plus de ${AGING_WAITING_FOR_DAYS} jours.`,
+      { taskIds: agingWaitingFor.map((task) => task.id) }
+    )
+  );
+
+  const tasksWithDeadline = activeTasks.filter((task) => task.deadline !== null);
+  const overdueDeadlines = tasksWithDeadline.filter((task) => (task.deadline as string) < nowDate);
+  findings.push(
+    buildFinding(
+      "overdue_deadlines",
+      now,
+      overdueDeadlines.length,
+      tasksWithDeadline.length,
+      `${overdueDeadlines.length} tache(s) avec une deadline depassee.`,
+      { taskIds: overdueDeadlines.map((task) => task.id) }
+    )
+  );
+
+  const scheduledActive = activeTasks.filter((task) => task.bucket === "scheduled");
+  const windowStartDate = addDays(nowDate, -TREND_LONG_WINDOW_DAYS);
+  const completedInWindow = tasks.filter(
+    (task) =>
+      task.status === "completed" &&
+      task.completedAt !== null &&
+      toLocalDateString(task.completedAt) >= windowStartDate
+  );
+  const scheduledVsCompletedRatio = scheduledActive.length / Math.max(1, completedInWindow.length);
+  findings.push(
+    buildFinding(
+      "scheduled_vs_completed_ratio",
+      now,
+      scheduledVsCompletedRatio,
+      scheduledActive.length + completedInWindow.length,
+      `${scheduledActive.length} tache(s) planifiee(s) pour ${completedInWindow.length} tache(s) completee(s) sur ${TREND_LONG_WINDOW_DAYS} jours (ratio ${scheduledVsCompletedRatio.toFixed(2)}).`,
+      {
+        taskIds: [...scheduledActive.map((task) => task.id), ...completedInWindow.map((task) => task.id)],
+        severity: "info"
+      }
+    )
+  );
+
+  return findings;
+};

--- a/src/domain/insights/movement.test.ts
+++ b/src/domain/insights/movement.test.ts
@@ -1,0 +1,131 @@
+import type { PomodoroSessionDetails, Task } from "../types";
+import { computeWindowMovement } from "./movement";
+
+const sinceIso = "2026-02-01T08:00:00.000Z";
+const nowIso = "2026-02-01T12:00:00.000Z";
+
+const buildSession = (overrides: Partial<PomodoroSessionDetails>): PomodoroSessionDetails => ({
+  id: overrides.id ?? "session:default",
+  kind: "focus",
+  status: "completed",
+  startedAt: sinceIso,
+  endsAt: nowIso,
+  pausedRemainingMs: null,
+  completedAt: nowIso,
+  cancelledAt: null,
+  cycleIndex: 0,
+  date: "2026-02-01",
+  segments: [],
+  activeTaskId: null,
+  activeLabel: null,
+  taskIds: [],
+  ...overrides
+});
+
+const buildTask = (overrides: Partial<Task>): Task => ({
+  id: overrides.id ?? "task:default",
+  title: "Task",
+  notes: "",
+  status: "active",
+  bucket: "next_action",
+  contextIds: [],
+  projectId: null,
+  parentTaskId: null,
+  scheduledFor: null,
+  deadline: null,
+  recurringTemplateId: null,
+  recurrenceDueDate: null,
+  isRecurringInstance: false,
+  completedAt: null,
+  recurrenceGroupId: null,
+  pendingPastRecurrences: 0,
+  source: "manual",
+  sourceExternalId: null,
+  createdAt: sinceIso,
+  updatedAt: sinceIso,
+  ...overrides
+});
+
+describe("movement insight module", () => {
+  it("classifies a window as moved when a focus session completed inside it", () => {
+    const movement = computeWindowMovement({
+      sinceIso,
+      nowIso,
+      focusSessions: [buildSession({ completedAt: "2026-02-01T10:00:00.000Z" })],
+      tasks: [],
+      appOpenIntervals: []
+    });
+
+    expect(movement.completedFocusSessionCount).toBe(1);
+    expect(movement.completedTaskCount).toBe(0);
+    expect(movement.moved).toBe(true);
+  });
+
+  it("classifies a window as moved when a task completed inside it", () => {
+    const movement = computeWindowMovement({
+      sinceIso,
+      nowIso,
+      focusSessions: [],
+      tasks: [buildTask({ status: "completed", completedAt: "2026-02-01T09:00:00.000Z" })],
+      appOpenIntervals: []
+    });
+
+    expect(movement.completedTaskCount).toBe(1);
+    expect(movement.moved).toBe(true);
+  });
+
+  it("classifies a window with no movement", () => {
+    const movement = computeWindowMovement({
+      sinceIso,
+      nowIso,
+      focusSessions: [buildSession({ status: "cancelled", completedAt: null })],
+      tasks: [buildTask({ status: "active" })],
+      appOpenIntervals: []
+    });
+
+    expect(movement.moved).toBe(false);
+  });
+
+  it("ignores completions outside the window", () => {
+    const movement = computeWindowMovement({
+      sinceIso,
+      nowIso,
+      focusSessions: [buildSession({ completedAt: "2026-02-01T07:00:00.000Z" })],
+      tasks: [buildTask({ status: "completed", completedAt: "2026-02-01T13:00:00.000Z" })],
+      appOpenIntervals: []
+    });
+
+    expect(movement.moved).toBe(false);
+  });
+
+  it("ignores non-focus session kinds", () => {
+    const movement = computeWindowMovement({
+      sinceIso,
+      nowIso,
+      focusSessions: [buildSession({ kind: "short_break", completedAt: "2026-02-01T10:00:00.000Z" })],
+      tasks: [],
+      appOpenIntervals: []
+    });
+
+    expect(movement.completedFocusSessionCount).toBe(0);
+  });
+
+  it("merges overlapping app-open intervals and clamps them to the window", () => {
+    const movement = computeWindowMovement({
+      sinceIso,
+      nowIso,
+      focusSessions: [],
+      tasks: [],
+      appOpenIntervals: [
+        { startedAt: "2026-02-01T07:30:00.000Z", endedAt: "2026-02-01T09:00:00.000Z" },
+        { startedAt: "2026-02-01T08:30:00.000Z", endedAt: "2026-02-01T10:00:00.000Z" },
+        { startedAt: "2026-02-01T11:00:00.000Z", endedAt: "2026-02-01T13:00:00.000Z" }
+      ]
+    });
+
+    // Merged, clamped overlap: [08:00-10:00] (2h) + [11:00-12:00] (1h) = 3h out of a 4h window.
+    expect(movement.windowMs).toBe(4 * 60 * 60 * 1000);
+    expect(movement.appOpenMs).toBe(3 * 60 * 60 * 1000);
+    expect(movement.appOpenRatio).toBeCloseTo(0.75);
+  });
+});

--- a/src/domain/insights/movement.ts
+++ b/src/domain/insights/movement.ts
@@ -1,0 +1,94 @@
+import type { PomodoroSessionDetails, Task } from "../types";
+
+export interface AppOpenInterval {
+  startedAt: string;
+  endedAt: string;
+}
+
+export interface WindowMovementInput {
+  /** Start of the window, exclusive — usually the previous pulse's timestamp. */
+  sinceIso: string;
+  /** End of the window, inclusive — usually "now". */
+  nowIso: string;
+  focusSessions: PomodoroSessionDetails[];
+  tasks: Task[];
+  /** Periods the app was open/foregrounded, in any order and possibly overlapping. */
+  appOpenIntervals: AppOpenInterval[];
+}
+
+export interface WindowMovement {
+  sinceIso: string;
+  nowIso: string;
+  windowMs: number;
+  completedFocusSessionCount: number;
+  completedTaskCount: number;
+  appOpenMs: number;
+  /** Share of the window the app was open, clamped to [0, 1]. */
+  appOpenRatio: number;
+  /** Binary movement per spec `ai-integration-v2.md` §6.3: at least one focus session or one completed task. */
+  moved: boolean;
+}
+
+const mergeIntervals = (intervals: Array<[number, number]>): Array<[number, number]> => {
+  const sorted = [...intervals].sort((left, right) => left[0] - right[0]);
+  const merged: Array<[number, number]> = [];
+
+  for (const [start, end] of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && start <= last[1]) {
+      last[1] = Math.max(last[1], end);
+    } else {
+      merged.push([start, end]);
+    }
+  }
+
+  return merged;
+};
+
+/**
+ * Window movement (spec `ai-integration-v2.md` §3, §6.3): completed focus sessions and
+ * completed tasks since a reference time, plus how much of the window the app was open.
+ * Pure and deterministic — feeds the phase-2 pulse delta gate, but nothing calls it yet.
+ */
+export const computeWindowMovement = (input: WindowMovementInput): WindowMovement => {
+  const sinceMs = new Date(input.sinceIso).getTime();
+  const nowMs = new Date(input.nowIso).getTime();
+  const windowMs = Math.max(0, nowMs - sinceMs);
+
+  const isWithinWindow = (iso: string | null): boolean => {
+    if (!iso) {
+      return false;
+    }
+    const ms = new Date(iso).getTime();
+    return ms > sinceMs && ms <= nowMs;
+  };
+
+  const completedFocusSessionCount = input.focusSessions.filter(
+    (session) => session.kind === "focus" && session.status === "completed" && isWithinWindow(session.completedAt)
+  ).length;
+
+  const completedTaskCount = input.tasks.filter(
+    (task) => task.status === "completed" && isWithinWindow(task.completedAt)
+  ).length;
+
+  const clampedIntervals = input.appOpenIntervals
+    .map((interval): [number, number] => [
+      Math.max(sinceMs, new Date(interval.startedAt).getTime()),
+      Math.min(nowMs, new Date(interval.endedAt).getTime())
+    ])
+    .filter(([start, end]) => end > start);
+
+  const appOpenMs = mergeIntervals(clampedIntervals).reduce((sum, [start, end]) => sum + (end - start), 0);
+  const appOpenRatio = windowMs > 0 ? Math.min(1, appOpenMs / windowMs) : 0;
+
+  return {
+    sinceIso: input.sinceIso,
+    nowIso: input.nowIso,
+    windowMs,
+    completedFocusSessionCount,
+    completedTaskCount,
+    appOpenMs,
+    appOpenRatio,
+    moved: completedFocusSessionCount > 0 || completedTaskCount > 0
+  };
+};

--- a/src/domain/insights/shared.ts
+++ b/src/domain/insights/shared.ts
@@ -1,0 +1,47 @@
+import { addDays } from "../../lib/gtd/shared";
+import type { DailyEntry } from "../types";
+import type { EvidenceWindow } from "./types";
+
+/** Internal helpers shared across the insight engine modules. Not part of the spec's module table. */
+
+export const average = (values: number[]): number =>
+  values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+
+export const sortEntriesByDate = (entries: DailyEntry[]): DailyEntry[] =>
+  [...entries].sort((left, right) => left.date.localeCompare(right.date));
+
+export const daysBetweenDates = (from: string, to: string): number => {
+  const startMs = new Date(`${from}T12:00:00`).getTime();
+  const endMs = new Date(`${to}T12:00:00`).getTime();
+  return Math.round((endMs - startMs) / 86400000);
+};
+
+/** Entries whose date falls within the trailing `windowDays` ending at `referenceDate`, inclusive. */
+export const entriesInTrailingWindow = (
+  entries: DailyEntry[],
+  referenceDate: string,
+  windowDays: number
+): DailyEntry[] => {
+  const from = addDays(referenceDate, -(windowDays - 1));
+  return entries.filter((entry) => entry.date >= from && entry.date <= referenceDate);
+};
+
+export const buildEvidenceWindow = (from: string, to: string): EvidenceWindow => ({
+  from,
+  to,
+  days: daysBetweenDates(from, to) + 1
+});
+
+export const trailingEvidenceWindow = (referenceDate: string, windowDays: number): EvidenceWindow => {
+  const from = addDays(referenceDate, -(windowDays - 1));
+  return buildEvidenceWindow(from, referenceDate);
+};
+
+/** Latest date carried by `entries`, or `null` when there is no history. */
+export const latestEntryDate = (entries: DailyEntry[]): string | null => {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return sortEntriesByDate(entries)[entries.length - 1].date;
+};

--- a/src/domain/insights/streaks.test.ts
+++ b/src/domain/insights/streaks.test.ts
@@ -1,0 +1,62 @@
+import { addDays } from "../../lib/gtd/shared";
+import { createEmptyDailyEntry, updatePrinciple } from "../daily-entry";
+import type { DailyEntry, PrincipleKey } from "../types";
+import { computeStreakFindings } from "./streaks";
+
+const buildEntries = (startDate: string, values: boolean[], key: PrincipleKey): DailyEntry[] =>
+  values.map((value, index) => updatePrinciple(createEmptyDailyEntry(addDays(startDate, index)), key, value));
+
+describe("streaks insight module", () => {
+  it("computes current streak, longest streak, days since last true and 28-day rate", () => {
+    const values = [true, true, false, true, true, true, false, true, true, true];
+    const entries = buildEntries("2026-01-01", values, "priereDuMatin");
+
+    const findings = computeStreakFindings(entries);
+    const finding = findings.find((item) => item.principleKey === "priereDuMatin");
+
+    expect(finding).toBeDefined();
+    expect(finding?.currentStreak).toBe(3);
+    expect(finding?.longestStreak).toBe(3);
+    expect(finding?.daysSinceLastTrue).toBe(0);
+    expect(finding?.rate28d).toBeCloseTo(0.8);
+    expect(finding?.sampleSize).toBe(10);
+    expect(finding?.value).toBe(3);
+    expect(finding?.severity).toBe("positive");
+  });
+
+  it("reports daysSinceLastTrue as null when the principle was never true", () => {
+    const entries = buildEntries("2026-01-01", [false, false, false], "priereDuSoir");
+
+    const finding = computeStreakFindings(entries).find((item) => item.principleKey === "priereDuSoir");
+
+    expect(finding?.currentStreak).toBe(0);
+    expect(finding?.longestStreak).toBe(0);
+    expect(finding?.daysSinceLastTrue).toBeNull();
+  });
+
+  it("returns no findings for empty history", () => {
+    expect(computeStreakFindings([])).toEqual([]);
+  });
+
+  it("ignores null (unanswered) days when computing the 28-day rate", () => {
+    const entries = buildEntries("2026-01-01", [true, true], "ecriture");
+    entries.push(createEmptyDailyEntry("2026-01-03"));
+
+    const finding = computeStreakFindings(entries).find((item) => item.principleKey === "ecriture");
+
+    expect(finding?.sampleSize).toBe(2);
+    expect(finding?.rate28d).toBeCloseTo(1);
+  });
+
+  it("does not bridge a streak across a calendar-date gap between entries", () => {
+    const entries = [
+      updatePrinciple(createEmptyDailyEntry("2026-01-01"), "priereDuMatin", true),
+      updatePrinciple(createEmptyDailyEntry("2026-01-10"), "priereDuMatin", true)
+    ];
+
+    const finding = computeStreakFindings(entries).find((item) => item.principleKey === "priereDuMatin");
+
+    expect(finding?.currentStreak).toBe(1);
+    expect(finding?.longestStreak).toBe(1);
+  });
+});

--- a/src/domain/insights/streaks.test.ts
+++ b/src/domain/insights/streaks.test.ts
@@ -48,6 +48,18 @@ describe("streaks insight module", () => {
     expect(finding?.rate28d).toBeCloseTo(1);
   });
 
+  it("skips past an unanswered reference day to find the last answered day for currentStreak", () => {
+    const trueEntries = buildEntries("2026-01-01", Array.from({ length: 10 }, () => true), "priereDuMatin");
+    const unansweredToday = createEmptyDailyEntry("2026-01-11");
+    const entries = [...trueEntries, unansweredToday];
+
+    const finding = computeStreakFindings(entries).find((item) => item.principleKey === "priereDuMatin");
+
+    expect(finding?.currentStreak).toBe(10);
+    expect(finding?.longestStreak).toBe(10);
+    expect(finding?.daysSinceLastTrue).toBe(1);
+  });
+
   it("does not bridge a streak across a calendar-date gap between entries", () => {
     const entries = [
       updatePrinciple(createEmptyDailyEntry("2026-01-01"), "priereDuMatin", true),

--- a/src/domain/insights/streaks.ts
+++ b/src/domain/insights/streaks.ts
@@ -1,0 +1,96 @@
+import { principleDefinitions } from "../definitions";
+import type { DailyEntry, PrincipleKey } from "../types";
+import { TREND_LONG_WINDOW_DAYS } from "./constants";
+import { daysBetweenDates, entriesInTrailingWindow, latestEntryDate, sortEntriesByDate, trailingEvidenceWindow } from "./shared";
+import type { Finding } from "./types";
+
+export interface StreakFinding extends Finding {
+  principleKey: PrincipleKey;
+  /** Consecutive `true` days ending at the reference date (0 when the most recent answered day is false/unanswered). */
+  currentStreak: number;
+  /** Longest run of consecutive `true` days across the whole provided history. */
+  longestStreak: number;
+  /** Days elapsed since the last `true`, or `null` when the principle was never `true` in the history. */
+  daysSinceLastTrue: number | null;
+  /** Share of the trailing 28-day window (or shorter, if less history exists) answered `true`. */
+  rate28d: number;
+}
+
+/**
+ * Per-principle streak stats (spec `ai-integration-v2.md` §3): current streak, longest streak,
+ * days since last `true`, 28-day rate. `referenceDate` defaults to the most recent entry's date.
+ */
+export const computeStreakFindings = (entries: DailyEntry[], referenceDate?: string): StreakFinding[] => {
+  const ordered = sortEntriesByDate(entries);
+  const reference = referenceDate ?? latestEntryDate(ordered);
+
+  if (!reference) {
+    return [];
+  }
+
+  const upToReference = ordered.filter((entry) => entry.date <= reference);
+  const windowEntries = entriesInTrailingWindow(upToReference, reference, TREND_LONG_WINDOW_DAYS);
+  const evidenceWindow = trailingEvidenceWindow(reference, TREND_LONG_WINDOW_DAYS);
+
+  return principleDefinitions.map(({ key }) => {
+    let currentStreak = 0;
+    let currentStreakPreviousDate: string | null = null;
+    for (let index = upToReference.length - 1; index >= 0; index -= 1) {
+      const entry = upToReference[index];
+      if (entry.principleChecks[key] !== true) {
+        break;
+      }
+      if (currentStreakPreviousDate !== null && daysBetweenDates(entry.date, currentStreakPreviousDate) !== 1) {
+        break;
+      }
+      currentStreak += 1;
+      currentStreakPreviousDate = entry.date;
+    }
+
+    let longestStreak = 0;
+    let runningStreak = 0;
+    let longestStreakPreviousDate: string | null = null;
+    for (const entry of upToReference) {
+      if (entry.principleChecks[key] === true) {
+        runningStreak =
+          longestStreakPreviousDate !== null && daysBetweenDates(longestStreakPreviousDate, entry.date) === 1
+            ? runningStreak + 1
+            : 1;
+        longestStreak = Math.max(longestStreak, runningStreak);
+        longestStreakPreviousDate = entry.date;
+      } else {
+        runningStreak = 0;
+        longestStreakPreviousDate = null;
+      }
+    }
+
+    let daysSinceLastTrue: number | null = null;
+    for (let index = upToReference.length - 1; index >= 0; index -= 1) {
+      if (upToReference[index].principleChecks[key] === true) {
+        daysSinceLastTrue = daysBetweenDates(upToReference[index].date, reference);
+        break;
+      }
+    }
+
+    const answeredInWindow = windowEntries.filter((entry) => entry.principleChecks[key] !== null);
+    const trueInWindow = answeredInWindow.filter((entry) => entry.principleChecks[key] === true);
+    const rate28d = answeredInWindow.length > 0 ? trueInWindow.length / answeredInWindow.length : 0;
+
+    const severity: StreakFinding["severity"] =
+      currentStreak >= 3 ? "positive" : daysSinceLastTrue !== null && daysSinceLastTrue >= 3 ? "watch" : "info";
+
+    return {
+      id: `streak:${key}:${reference}`,
+      severity,
+      evidenceWindow,
+      sampleSize: answeredInWindow.length,
+      value: currentStreak,
+      label: `Streak actuel de ${currentStreak} jour(s) pour ${key} (taux 28j: ${Math.round(rate28d * 100)}%).`,
+      principleKey: key,
+      currentStreak,
+      longestStreak,
+      daysSinceLastTrue,
+      rate28d
+    };
+  });
+};

--- a/src/domain/insights/streaks.ts
+++ b/src/domain/insights/streaks.ts
@@ -6,7 +6,15 @@ import type { Finding } from "./types";
 
 export interface StreakFinding extends Finding {
   principleKey: PrincipleKey;
-  /** Consecutive `true` days ending at the reference date (0 when the most recent answered day is false/unanswered). */
+  /**
+   * Consecutive `true` days counted back from the most recent *answered* day at or before the
+   * reference date — any number of trailing unanswered (`null`) days right at the reference end
+   * are skipped over rather than breaking the streak, since they represent "not logged yet", not
+   * "failed". The streak still breaks on an explicit `false` or on an actual calendar gap between
+   * two `true` days. This means `currentStreak` can lag `daysSinceLastTrue`: e.g. 3 `true` days
+   * followed by 5 unanswered days reports `currentStreak: 3` and `daysSinceLastTrue: 5` — that's
+   * intended, not a bug.
+   */
   currentStreak: number;
   /** Longest run of consecutive `true` days across the whole provided history. */
   longestStreak: number;
@@ -37,8 +45,21 @@ export const computeStreakFindings = (entries: DailyEntry[], referenceDate?: str
     let currentStreakPreviousDate: string | null = null;
     for (let index = upToReference.length - 1; index >= 0; index -= 1) {
       const entry = upToReference[index];
-      if (entry.principleChecks[key] !== true) {
+      const checkValue = entry.principleChecks[key];
+      if (checkValue === false) {
         break;
+      }
+      if (checkValue === null) {
+        // An unanswered day (as opposed to an explicit `false`) doesn't end the streak — skip
+        // past it to find the most recent *answered* day, per this field's own docstring. It
+        // doesn't count towards `currentStreak` itself. This skip only helps a *trailing* run of
+        // unanswered days right at the reference end, where `currentStreakPreviousDate` hasn't
+        // been set yet. Once an answered day has been found and `currentStreakPreviousDate` is
+        // set, an unanswered day *between* two `true` days does not get bridged: the
+        // date-contiguity check below still compares the older `true` directly against the more
+        // recent one's date, so `true, null, true` correctly breaks the streak (currentStreak: 1),
+        // rather than counting both.
+        continue;
       }
       if (currentStreakPreviousDate !== null && daysBetweenDates(entry.date, currentStreakPreviousDate) !== 1) {
         break;

--- a/src/domain/insights/trends.test.ts
+++ b/src/domain/insights/trends.test.ts
@@ -1,0 +1,59 @@
+import { addDays } from "../../lib/gtd/shared";
+import { createEmptyDailyEntry, updateMetric } from "../daily-entry";
+import type { DailyEntry } from "../types";
+import { computeMetricTrendFindings, computeWeeklyScoreTrend } from "./trends";
+
+const buildEntries = (startDate: string, values: number[]): DailyEntry[] =>
+  values.map((value, index) => updateMetric(createEmptyDailyEntry(addDays(startDate, index)), "course", value));
+
+describe("trends insight module", () => {
+  it("computes 7-day and 28-day trailing averages, delta and direction per metric", () => {
+    const entries = buildEntries("2026-01-01", [10, 10, 10, 20, 20, 20, 20, 20, 20, 20]);
+
+    const finding = computeMetricTrendFindings(entries).find((item) => item.metricKey === "course");
+
+    expect(finding?.average7d).toBeCloseTo(20);
+    expect(finding?.average28d).toBeCloseTo(17);
+    expect(finding?.delta).toBeCloseTo(3);
+    expect(finding?.direction).toBe("up");
+    expect(finding?.sampleSize).toBe(10);
+    expect(finding?.value).toBeCloseTo(20);
+  });
+
+  it("reports a flat direction when the short-term average barely moves", () => {
+    const entries = buildEntries("2026-01-01", [20, 20, 20, 20, 20, 20, 20, 20, 20, 20]);
+
+    const finding = computeMetricTrendFindings(entries).find((item) => item.metricKey === "course");
+
+    expect(finding?.direction).toBe("flat");
+  });
+
+  it("returns no findings for empty history", () => {
+    expect(computeMetricTrendFindings([])).toEqual([]);
+  });
+
+  it("computes the weekly-score trajectory against prior weeks", () => {
+    const points = [
+      { weekStartDate: "2026-01-04", weeklyScore: 50 },
+      { weekStartDate: "2026-01-11", weeklyScore: 55 },
+      { weekStartDate: "2026-01-18", weeklyScore: 60 },
+      { weekStartDate: "2026-01-25", weeklyScore: 80 }
+    ];
+
+    const finding = computeWeeklyScoreTrend(points);
+
+    expect(finding?.latestScore).toBe(80);
+    expect(finding?.baselineAverage).toBeCloseTo(55);
+    expect(finding?.delta).toBeCloseTo(25);
+    expect(finding?.direction).toBe("up");
+    expect(finding?.sampleSize).toBe(3);
+  });
+
+  it("returns null for the weekly-score trajectory with no history", () => {
+    expect(computeWeeklyScoreTrend([])).toBeNull();
+  });
+
+  it("returns null for the weekly-score trajectory with a single point (no prior weeks to compare)", () => {
+    expect(computeWeeklyScoreTrend([{ weekStartDate: "2026-01-04", weeklyScore: 50 }])).toBeNull();
+  });
+});

--- a/src/domain/insights/trends.test.ts
+++ b/src/domain/insights/trends.test.ts
@@ -32,6 +32,19 @@ describe("trends insight module", () => {
     expect(computeMetricTrendFindings([])).toEqual([]);
   });
 
+  it("does not report a false down trend when the trailing 7-day window has no observations", () => {
+    // 14 days at 30/day, then a 7-day gap in tracking (no entries for the trailing week).
+    const entries = buildEntries("2026-01-01", Array.from({ length: 14 }, () => 30));
+
+    const finding = computeMetricTrendFindings(entries, "2026-01-21").find((item) => item.metricKey === "course");
+
+    expect(finding?.shortSampleSize).toBe(0);
+    expect(finding?.average7d).toBe(0);
+    expect(finding?.average28d).toBeCloseTo(30);
+    expect(finding?.delta).toBe(0);
+    expect(finding?.direction).toBe("flat");
+  });
+
   it("computes the weekly-score trajectory against prior weeks", () => {
     const points = [
       { weekStartDate: "2026-01-04", weeklyScore: 50 },

--- a/src/domain/insights/trends.ts
+++ b/src/domain/insights/trends.ts
@@ -22,6 +22,8 @@ export interface MetricTrendFinding extends Finding {
   metricKey: MetricKey;
   average7d: number;
   average28d: number;
+  /** Number of observations backing `average7d`. `0` means the trailing 7-day window has no data — `direction` is forced to `"flat"` and `delta` to `0` in that case, since there is nothing to compare against the 28-day average. */
+  shortSampleSize: number;
   delta: number;
   direction: TrendDirection;
 }
@@ -51,10 +53,14 @@ export const computeMetricTrendFindings = (entries: DailyEntry[], referenceDate?
       .map((entry) => resolveMetricValue(entry, key))
       .filter((value): value is number => value !== null);
 
+    const shortSampleSize = shortValues.length;
     const average7d = average(shortValues);
     const average28d = average(longValues);
-    const delta = average7d - average28d;
-    const direction = resolveDirection(delta, average28d);
+    // With no observations in the trailing 7-day window, `average7d` is a meaningless 0 (not
+    // "the metric collapsed to zero"), so the comparison against the 28-day average is suppressed
+    // rather than reported as a `"down"` trend.
+    const delta = shortSampleSize > 0 ? average7d - average28d : 0;
+    const direction = shortSampleSize > 0 ? resolveDirection(delta, average28d) : "flat";
 
     return {
       id: `trend:${key}:${reference}`,
@@ -62,10 +68,14 @@ export const computeMetricTrendFindings = (entries: DailyEntry[], referenceDate?
       evidenceWindow,
       sampleSize: longValues.length,
       value: average7d,
-      label: `Moyenne 7j de ${key}: ${average7d.toFixed(1)} (moyenne 28j: ${average28d.toFixed(1)}, tendance ${direction}).`,
+      label:
+        shortSampleSize > 0
+          ? `Moyenne 7j de ${key}: ${average7d.toFixed(1)} (moyenne 28j: ${average28d.toFixed(1)}, tendance ${direction}).`
+          : `Pas de donnee pour ${key} sur les 7 derniers jours (moyenne 28j: ${average28d.toFixed(1)}).`,
       metricKey: key,
       average7d,
       average28d,
+      shortSampleSize,
       delta,
       direction
     };

--- a/src/domain/insights/trends.ts
+++ b/src/domain/insights/trends.ts
@@ -1,0 +1,121 @@
+import { resolveMetricValue } from "../daily-entry";
+import { metricDefinitions } from "../definitions";
+import type { DailyEntry, MetricKey } from "../types";
+import { TREND_LONG_WINDOW_DAYS, TREND_SHORT_WINDOW_DAYS } from "./constants";
+import { average, entriesInTrailingWindow, latestEntryDate, sortEntriesByDate, trailingEvidenceWindow } from "./shared";
+import type { Finding } from "./types";
+
+export type TrendDirection = "up" | "down" | "flat";
+
+const resolveDirection = (delta: number, baseline: number): TrendDirection => {
+  const epsilon = Math.max(0.001, Math.abs(baseline) * 0.02);
+  if (delta > epsilon) {
+    return "up";
+  }
+  if (delta < -epsilon) {
+    return "down";
+  }
+  return "flat";
+};
+
+export interface MetricTrendFinding extends Finding {
+  metricKey: MetricKey;
+  average7d: number;
+  average28d: number;
+  delta: number;
+  direction: TrendDirection;
+}
+
+/**
+ * Per-metric 7-day and 28-day trailing averages, their delta and direction
+ * (spec `ai-integration-v2.md` §3). `referenceDate` defaults to the most recent entry's date.
+ */
+export const computeMetricTrendFindings = (entries: DailyEntry[], referenceDate?: string): MetricTrendFinding[] => {
+  const ordered = sortEntriesByDate(entries);
+  const reference = referenceDate ?? latestEntryDate(ordered);
+
+  if (!reference) {
+    return [];
+  }
+
+  const upToReference = ordered.filter((entry) => entry.date <= reference);
+  const shortWindow = entriesInTrailingWindow(upToReference, reference, TREND_SHORT_WINDOW_DAYS);
+  const longWindow = entriesInTrailingWindow(upToReference, reference, TREND_LONG_WINDOW_DAYS);
+  const evidenceWindow = trailingEvidenceWindow(reference, TREND_LONG_WINDOW_DAYS);
+
+  return metricDefinitions.map(({ key }) => {
+    const shortValues = shortWindow
+      .map((entry) => resolveMetricValue(entry, key))
+      .filter((value): value is number => value !== null);
+    const longValues = longWindow
+      .map((entry) => resolveMetricValue(entry, key))
+      .filter((value): value is number => value !== null);
+
+    const average7d = average(shortValues);
+    const average28d = average(longValues);
+    const delta = average7d - average28d;
+    const direction = resolveDirection(delta, average28d);
+
+    return {
+      id: `trend:${key}:${reference}`,
+      severity: "info",
+      evidenceWindow,
+      sampleSize: longValues.length,
+      value: average7d,
+      label: `Moyenne 7j de ${key}: ${average7d.toFixed(1)} (moyenne 28j: ${average28d.toFixed(1)}, tendance ${direction}).`,
+      metricKey: key,
+      average7d,
+      average28d,
+      delta,
+      direction
+    };
+  });
+};
+
+export interface WeeklyScoreTrendPoint {
+  weekStartDate: string;
+  weeklyScore: number;
+}
+
+export interface WeeklyScoreTrendFinding extends Finding {
+  latestWeekStartDate: string;
+  latestScore: number;
+  baselineAverage: number;
+  delta: number;
+  direction: TrendDirection;
+}
+
+/**
+ * Weekly-score trajectory (spec `ai-integration-v2.md` §3): the most recent weekly score
+ * versus the average of prior weeks. `points` must be ordered oldest to newest.
+ */
+export const computeWeeklyScoreTrend = (points: WeeklyScoreTrendPoint[]): WeeklyScoreTrendFinding | null => {
+  if (points.length < 2) {
+    return null;
+  }
+
+  const ordered = [...points].sort((left, right) => left.weekStartDate.localeCompare(right.weekStartDate));
+  const latest = ordered[ordered.length - 1];
+  const priorWeeks = ordered.slice(0, -1);
+  const baselineAverage = average(priorWeeks.map((point) => point.weeklyScore));
+  const delta = latest.weeklyScore - baselineAverage;
+  const direction = resolveDirection(delta, baselineAverage);
+
+  return {
+    id: `trend:weekly_score:${latest.weekStartDate}`,
+    severity: "info",
+    evidenceWindow: {
+      from: ordered[0].weekStartDate,
+      to: latest.weekStartDate,
+      days: ordered.length * 7
+    },
+    sampleSize: priorWeeks.length,
+    value: latest.weeklyScore,
+    label: `Score hebdomadaire de la derniere semaine: ${latest.weeklyScore.toFixed(1)} (moyenne des semaines precedentes: ${baselineAverage.toFixed(1)}, tendance ${direction}).`,
+    latestWeekStartDate: latest.weekStartDate,
+    latestScore: latest.weeklyScore,
+    baselineAverage,
+    delta,
+    direction
+  };
+};

--- a/src/domain/insights/types.ts
+++ b/src/domain/insights/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared shape for the deterministic insight engine (spec `ai-integration-v2.md` §3).
+ *
+ * Every module under `src/domain/insights/` is a pure function over already-loaded
+ * data (no repository access). Each finding it produces conforms to this shape plus
+ * module-specific fields, so a caller can render the top finding without a model.
+ */
+
+export type FindingSeverity = "info" | "positive" | "watch";
+
+/** The span of history a finding was computed over. */
+export interface EvidenceWindow {
+  /** Local `YYYY-MM-DD` date the window starts at (inclusive). */
+  from: string;
+  /** Local `YYYY-MM-DD` date the window ends at (inclusive). */
+  to: string;
+  /** Number of calendar days spanned by the window. */
+  days: number;
+}
+
+export interface Finding {
+  id: string;
+  severity: FindingSeverity;
+  evidenceWindow: EvidenceWindow;
+  sampleSize: number;
+  value: number;
+  /** Human-readable observation. Never causal ("associe a", never "cause"/"entraine"). */
+  label: string;
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -268,6 +268,8 @@ export interface RescueTimeTaxonomyEntry {
   hours: number;
 }
 
+export type AiPayloadScope = "metrics" | "metrics_and_structure" | "full";
+
 export interface AppSettings {
   language: "fr";
   storageMode: "sqlite";
@@ -275,6 +277,7 @@ export interface AppSettings {
   aiApiKey: string;
   aiBaseUrl: string;
   aiModel: string;
+  aiPayloadScope: AiPayloadScope;
   rescuetimeApiKey: string;
   autoBackupEnabled: boolean;
   autoBackupIntervalHours: number;

--- a/src/domain/weekly-review.ts
+++ b/src/domain/weekly-review.ts
@@ -11,9 +11,9 @@ import type {
   WeeklyRitualSectionKey
 } from "./types";
 
-const phoneScreenTargetMinutes = 840;
-const pomodoroTarget = 56;
-const calorieTargetDaily = 3800;
+export const phoneScreenTargetMinutes = 840;
+export const pomodoroTarget = 56;
+export const calorieTargetDaily = 3800;
 
 const emptyWeeklyNotes = (): WeeklyReviewNotes => ({
   bilan: "",

--- a/src/lib/ai/context/daily-snapshot.test.ts
+++ b/src/lib/ai/context/daily-snapshot.test.ts
@@ -1,0 +1,134 @@
+import { createEmptyDailyEntry, updateMetric, updateNote, updatePrinciple } from "../../../domain/daily-entry";
+import type { PomodoroTaskSummary, Project, Task } from "../../../domain/types";
+import { buildDailySnapshot, type DailySnapshotInputs } from "./daily-snapshot";
+
+const now = "2026-02-01T12:00:00.000Z";
+
+const buildEntry = () => {
+  let entry = createEmptyDailyEntry("2026-02-01");
+  entry = updateMetric(entry, "pomodoris", 6);
+  entry = updatePrinciple(entry, "priereDuMatin", true);
+  entry = updateNote(entry, "morningIntention", "Ecrire le module d'insights.");
+  entry = updateNote(entry, "nightReflection", "Bonne avancee aujourd'hui.");
+  entry = updateNote(entry, "tomorrowFocus", "Terminer le context builder.");
+  return entry;
+};
+
+const buildProject = (overrides: Partial<Project>): Project => ({
+  id: overrides.id ?? "project:default",
+  title: "Projet sans next action",
+  status: "active",
+  statusChangedAt: now,
+  notes: "",
+  contextIds: [],
+  source: "manual",
+  sourceExternalId: null,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides
+});
+
+const buildTask = (overrides: Partial<Task>): Task => ({
+  id: overrides.id ?? "task:default",
+  title: "Tache",
+  notes: "",
+  status: "active",
+  bucket: "next_action",
+  contextIds: [],
+  projectId: null,
+  parentTaskId: null,
+  scheduledFor: null,
+  deadline: null,
+  recurringTemplateId: null,
+  recurrenceDueDate: null,
+  isRecurringInstance: false,
+  completedAt: null,
+  recurrenceGroupId: null,
+  pendingPastRecurrences: 0,
+  source: "manual",
+  sourceExternalId: null,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides
+});
+
+const buildInputs = (): DailySnapshotInputs => {
+  const entry = buildEntry();
+  const projectWithoutNextAction = buildProject({ id: "project:without-next-action" });
+  const projectWithNextAction = buildProject({ id: "project:with-next-action", title: "Projet actif" });
+  const tasks: Task[] = [
+    buildTask({ id: "task:next-action", bucket: "next_action", projectId: projectWithNextAction.id })
+  ];
+  const pomodoroTaskSummaries: PomodoroTaskSummary[] = [
+    { taskId: "task:next-action", taskTitle: "Tache prioritaire", totalSeconds: 3000, sessionCount: 4 },
+    { taskId: "task:other", taskTitle: "Autre tache", totalSeconds: 600, sessionCount: 1 }
+  ];
+
+  return {
+    date: "2026-02-01",
+    entry,
+    historyEntries: [entry],
+    tasks,
+    projects: [projectWithoutNextAction, projectWithNextAction],
+    pomodoroTaskSummaries,
+    completedFocusSessionCount: 5,
+    productivityPulseWeekToDate: 70,
+    rescuetimeConfigured: true,
+    now
+  };
+};
+
+describe("daily snapshot context builder", () => {
+  it("always includes numbers, aggregates, principle booleans and findings", () => {
+    const snapshot = buildDailySnapshot(buildInputs(), "metrics");
+
+    expect(snapshot.metrics.find((metric) => metric.key === "pomodoris")?.todayValue).toBe(6);
+    expect(snapshot.principles.find((principle) => principle.key === "priereDuMatin")?.todayValue).toBe(true);
+    expect(snapshot.gtd.projectsWithoutNextAction).toBe(1);
+    expect(snapshot.findings.length).toBeGreaterThan(0);
+  });
+
+  it("omits free text and titles at the metrics scope", () => {
+    const snapshot = buildDailySnapshot(buildInputs(), "metrics");
+    const json = JSON.parse(JSON.stringify(snapshot));
+
+    expect("notes" in json).toBe(false);
+    expect(json.gtd.projectsWithoutNextActionSample.every((item: { title?: string }) => !("title" in item))).toBe(
+      true
+    );
+    expect("title" in json.pomodoro.topTask).toBe(false);
+  });
+
+  it("includes task titles and project names at the metrics_and_structure scope, but not free text", () => {
+    const snapshot = buildDailySnapshot(buildInputs(), "metrics_and_structure");
+    const json = JSON.parse(JSON.stringify(snapshot));
+
+    expect("notes" in json).toBe(false);
+    expect(json.gtd.projectsWithoutNextActionSample[0].title).toBe("Projet sans next action");
+    expect(json.pomodoro.topTask.title).toBe("Tache prioritaire");
+  });
+
+  it("includes notes, reflections and titles at the full scope", () => {
+    const snapshot = buildDailySnapshot(buildInputs(), "full");
+    const json = JSON.parse(JSON.stringify(snapshot));
+
+    expect(json.notes.morningIntention).toBe("Ecrire le module d'insights.");
+    expect(json.notes.nightReflection).toBe("Bonne avancee aujourd'hui.");
+    expect(json.notes.tomorrowFocus).toBe("Terminer le context builder.");
+    expect(json.pomodoro.topTask.title).toBe("Tache prioritaire");
+  });
+
+  it("reports the top pomodoro task by total focus seconds", () => {
+    const snapshot = buildDailySnapshot(buildInputs(), "full");
+
+    expect(snapshot.pomodoro.topTask?.taskId).toBe("task:next-action");
+    expect(snapshot.pomodoro.totalFocusMinutes).toBe(60);
+  });
+
+  it("labels the RescueTime pulse as week-to-date rather than a same-day figure", () => {
+    const snapshot = buildDailySnapshot(buildInputs(), "full");
+
+    expect(snapshot.rescueTime.productivityPulseWeekToDate).toBe(70);
+    expect("productivityPulse" in snapshot.rescueTime).toBe(false);
+  });
+});

--- a/src/lib/ai/context/daily-snapshot.test.ts
+++ b/src/lib/ai/context/daily-snapshot.test.ts
@@ -99,6 +99,69 @@ describe("daily snapshot context builder", () => {
     expect("title" in json.pomodoro.topTask).toBe(false);
   });
 
+  it("never leaks raw task/project identifiers through findings at the metrics scope", () => {
+    // Isolated from `buildInputs()` on purpose: `projectsWithoutNextActionSample`/`pomodoro.topTask`
+    // already expose a capped, always-present raw id at every scope (only their `title` is scope-gated,
+    // by existing design) — this fixture avoids both so the only remaining source of a "task:"/"project:"
+    // substring is the raw `taskIds`/`projectIds` carried by `gtd-health.ts` findings.
+    const entry = buildEntry();
+    const projectWithNextAction = buildProject({ id: "project:with-next-action" });
+    const tasks: Task[] = [
+      buildTask({ id: "task:next-action", bucket: "next_action", projectId: projectWithNextAction.id }),
+      buildTask({ id: "task:scheduled", bucket: "scheduled" }),
+      buildTask({ id: "task:completed", status: "completed", bucket: "next_action", completedAt: now })
+    ];
+    const inputs: DailySnapshotInputs = {
+      date: "2026-02-01",
+      entry,
+      historyEntries: [entry],
+      tasks,
+      projects: [projectWithNextAction],
+      pomodoroTaskSummaries: [],
+      completedFocusSessionCount: 5,
+      productivityPulseWeekToDate: 70,
+      rescuetimeConfigured: true,
+      now
+    };
+
+    const snapshot = buildDailySnapshot(inputs, "metrics");
+    const json = JSON.stringify(snapshot);
+
+    expect(json).not.toContain("task:");
+    expect(json).not.toContain("project:");
+    // Sanity check: the scheduled-vs-completed finding that normally carries these ids is actually
+    // present with a non-empty population, so the assertion above exercises the redaction rather
+    // than an empty findings array.
+    const ratioFinding = snapshot.findings.find((finding) => finding.id.startsWith("gtd_health:scheduled_vs_completed_ratio"));
+    expect(ratioFinding).toBeDefined();
+    expect(ratioFinding?.sampleSize).toBeGreaterThan(0);
+  });
+
+  it("keeps raw task identifiers in findings at the metrics_and_structure scope", () => {
+    const entry = buildEntry();
+    const tasks: Task[] = [
+      buildTask({ id: "task:scheduled", bucket: "scheduled" }),
+      buildTask({ id: "task:completed", status: "completed", bucket: "next_action", completedAt: now })
+    ];
+    const inputs: DailySnapshotInputs = {
+      date: "2026-02-01",
+      entry,
+      historyEntries: [entry],
+      tasks,
+      projects: [],
+      pomodoroTaskSummaries: [],
+      completedFocusSessionCount: 5,
+      productivityPulseWeekToDate: 70,
+      rescuetimeConfigured: true,
+      now
+    };
+
+    const snapshot = buildDailySnapshot(inputs, "metrics_and_structure");
+    const json = JSON.stringify(snapshot);
+
+    expect(json).toContain("task:");
+  });
+
   it("includes task titles and project names at the metrics_and_structure scope, but not free text", () => {
     const snapshot = buildDailySnapshot(buildInputs(), "metrics_and_structure");
     const json = JSON.parse(JSON.stringify(snapshot));

--- a/src/lib/ai/context/daily-snapshot.ts
+++ b/src/lib/ai/context/daily-snapshot.ts
@@ -45,7 +45,8 @@ export interface DailySnapshotMetric {
   unit: string | null;
   target: number | null;
   todayValue: number | null;
-  average7d: number;
+  /** `null` when the trailing 7-day window has no observations for this metric — never a fake `0`. */
+  average7d: number | null;
   average28d: number;
   delta: number;
   direction: TrendDirection;
@@ -148,6 +149,32 @@ const projectTitleById = (projects: Project[]): Map<string, string> =>
   new Map(projects.map((project) => [project.id, project.title]));
 
 /**
+ * Strips finding fields that are safe to *compute* but not safe to *expose* below
+ * `metrics_and_structure` scope, mirroring the `projectsWithoutNextActionSample` id/title
+ * gate below. `findings` is a heterogeneous array of concrete finding subtypes spread in
+ * verbatim; the declared `Finding` shape (`id, severity, evidenceWindow, sampleSize, value,
+ * label`) plus module-specific scalars (e.g. `direction`, `principleKey`) are fixed,
+ * predefined-enum values and carry no user data. `gtd-health.ts` findings are the exception:
+ * they carry raw `taskIds`/`projectIds` arrays (every matching task/project id, unbounded),
+ * which are real user-created identifiers and must not survive at the restrictive `metrics`
+ * scope. Any future finding type that adds its own identifier array must extend this
+ * function so `findings` stays leak-free by construction rather than by every caller
+ * remembering to redact.
+ */
+const sanitizeFindingForScope = (finding: Finding, includeStructure: boolean): Finding => {
+  if (includeStructure) {
+    return finding;
+  }
+
+  const { taskIds: _taskIds, projectIds: _projectIds, ...rest } = finding as Finding & {
+    taskIds?: string[];
+    projectIds?: string[];
+  };
+
+  return rest as Finding;
+};
+
+/**
  * Builds the typed, labelled, compact daily snapshot (spec `ai-integration-v2.md` §5) from
  * already-fetched repository data and insight findings. Redaction is applied centrally here
  * based on `scope`, so no caller can leak a field by forgetting to redact.
@@ -178,7 +205,7 @@ export const buildDailySnapshot = (inputs: DailySnapshotInputs, scope: AiPayload
       unit: definition.unit ?? null,
       target: metricDailyTargets[definition.key] ?? null,
       todayValue: resolveMetricValue(inputs.entry, definition.key),
-      average7d: trend?.average7d ?? 0,
+      average7d: trend && trend.shortSampleSize > 0 ? trend.average7d : null,
       average28d: trend?.average28d ?? 0,
       delta: trend?.delta ?? 0,
       direction: trend?.direction ?? "flat"
@@ -267,7 +294,7 @@ export const buildDailySnapshot = (inputs: DailySnapshotInputs, scope: AiPayload
     ...gtdHealthFindings,
     ...focusFindings,
     ...(weeklyScoreTrend ? [weeklyScoreTrend] : [])
-  ];
+  ].map((finding) => sanitizeFindingForScope(finding, includeStructure));
 
   return {
     surface: "daily",

--- a/src/lib/ai/context/daily-snapshot.ts
+++ b/src/lib/ai/context/daily-snapshot.ts
@@ -1,0 +1,295 @@
+import { computeAnomalyFindings } from "../../../domain/insights/anomalies";
+import { computeCorrelationFindings } from "../../../domain/insights/correlations";
+import { computeFocusFindings } from "../../../domain/insights/focus";
+import { computeGtdHealthFindings } from "../../../domain/insights/gtd-health";
+import {
+  average,
+  entriesInTrailingWindow,
+  sortEntriesByDate
+} from "../../../domain/insights/shared";
+import { computeStreakFindings } from "../../../domain/insights/streaks";
+import type { Finding } from "../../../domain/insights/types";
+import {
+  computeMetricTrendFindings,
+  computeWeeklyScoreTrend,
+  type TrendDirection,
+  type WeeklyScoreTrendFinding,
+  type WeeklyScoreTrendPoint
+} from "../../../domain/insights/trends";
+import { TREND_LONG_WINDOW_DAYS, TREND_SHORT_WINDOW_DAYS } from "../../../domain/insights/constants";
+import { computeDisciplineScore, resolveMetricValue } from "../../../domain/daily-entry";
+import { metricDefinitions, principleDefinitions } from "../../../domain/definitions";
+import { calorieTargetDaily, phoneScreenTargetMinutes, pomodoroTarget } from "../../../domain/weekly-review";
+import type {
+  AiPayloadScope,
+  DailyEntry,
+  DailyStatus,
+  MetricKey,
+  PomodoroTaskSummary,
+  PrincipleKey,
+  Project,
+  Task
+} from "../../../domain/types";
+import type { Surface } from "./types";
+
+/** Daily metric targets known from existing product constants. `null` where none is defined yet. */
+const metricDailyTargets: Partial<Record<MetricKey, number>> = {
+  tempsEcranTelephone: phoneScreenTargetMinutes / 7,
+  pomodoris: pomodoroTarget / 7,
+  depenseCalorique: calorieTargetDaily
+};
+
+export interface DailySnapshotMetric {
+  key: MetricKey;
+  label: string;
+  unit: string | null;
+  target: number | null;
+  todayValue: number | null;
+  average7d: number;
+  average28d: number;
+  delta: number;
+  direction: TrendDirection;
+}
+
+export interface DailySnapshotPrinciple {
+  key: PrincipleKey;
+  label: string;
+  timing: "morning" | "evening" | "anytime";
+  todayValue: boolean | null;
+  currentStreak: number;
+  longestStreak: number;
+  daysSinceLastTrue: number | null;
+  rate28d: number;
+}
+
+export interface DailySnapshotGtdSample {
+  id: string;
+  /** Present only at `metrics_and_structure` scope and above. */
+  title?: string;
+}
+
+export interface DailySnapshotGtd {
+  inboxBacklog: number;
+  projectsWithoutNextAction: number;
+  projectsWithoutNextActionSample: DailySnapshotGtdSample[];
+  staleNextActions: number;
+  agingWaitingFor: number;
+  overdueDeadlines: number;
+  scheduledVsCompletedRatio: number;
+}
+
+export interface DailySnapshotPomodoroTopTask {
+  taskId: string | null;
+  /** Present only at `metrics_and_structure` scope and above. */
+  title?: string;
+}
+
+export interface DailySnapshotPomodoro {
+  completedFocusSessionCount: number;
+  totalFocusMinutes: number;
+  taskConcentration: number | null;
+  topTask: DailySnapshotPomodoroTopTask | null;
+}
+
+export interface DailySnapshotRescueTime {
+  configured: boolean;
+  /** Sunday-to-date RescueTime pulse (0-100), not a same-day figure — see `computeFocusFindings`. */
+  productivityPulseWeekToDate: number | null;
+}
+
+export interface DailySnapshotHistory {
+  daysConsidered: number;
+  disciplineAverage7d: number;
+  disciplineAverage28d: number;
+}
+
+export interface DailySnapshotNotes {
+  morningIntention: string;
+  nightReflection: string;
+  tomorrowFocus: string;
+}
+
+export interface DailySnapshot {
+  surface: Surface;
+  scope: AiPayloadScope;
+  date: string;
+  status: DailyStatus;
+  metrics: DailySnapshotMetric[];
+  principles: DailySnapshotPrinciple[];
+  /** Present only at `full` scope. */
+  notes?: DailySnapshotNotes;
+  gtd: DailySnapshotGtd;
+  pomodoro: DailySnapshotPomodoro;
+  rescueTime: DailySnapshotRescueTime;
+  history: DailySnapshotHistory;
+  weeklyScoreTrend: WeeklyScoreTrendFinding | null;
+  findings: Finding[];
+}
+
+export interface DailySnapshotInputs {
+  /** Local `YYYY-MM-DD` date the snapshot is built for. */
+  date: string;
+  entry: DailyEntry;
+  /** History used for streaks/trends/correlations/anomalies. Should include `entry` itself. */
+  historyEntries: DailyEntry[];
+  weeklyScoreHistory?: WeeklyScoreTrendPoint[];
+  tasks: Task[];
+  projects: Project[];
+  pomodoroTaskSummaries: PomodoroTaskSummary[];
+  completedFocusSessionCount: number;
+  /** Sunday-to-date RescueTime pulse (0-100), not a same-day figure — see `computeFocusFindings`. */
+  productivityPulseWeekToDate: number | null;
+  rescuetimeConfigured: boolean;
+  /** ISO instant used as "now" for GTD/Pomodoro findings. */
+  now: string;
+}
+
+const projectTitleById = (projects: Project[]): Map<string, string> =>
+  new Map(projects.map((project) => [project.id, project.title]));
+
+/**
+ * Builds the typed, labelled, compact daily snapshot (spec `ai-integration-v2.md` §5) from
+ * already-fetched repository data and insight findings. Redaction is applied centrally here
+ * based on `scope`, so no caller can leak a field by forgetting to redact.
+ */
+export const buildDailySnapshot = (inputs: DailySnapshotInputs, scope: AiPayloadScope): DailySnapshot => {
+  const includeStructure = scope === "metrics_and_structure" || scope === "full";
+  const includeFreeText = scope === "full";
+
+  const ordered = sortEntriesByDate(inputs.historyEntries);
+  const streakFindings = computeStreakFindings(ordered, inputs.date);
+  const trendFindings = computeMetricTrendFindings(ordered, inputs.date);
+  const correlationFindings = computeCorrelationFindings(ordered);
+  const anomalyFindings = computeAnomalyFindings(ordered, inputs.date);
+  const gtdHealthFindings = computeGtdHealthFindings(inputs.tasks, inputs.projects, inputs.now);
+  const focusFindings = computeFocusFindings(
+    inputs.pomodoroTaskSummaries,
+    inputs.completedFocusSessionCount,
+    inputs.now,
+    inputs.productivityPulseWeekToDate
+  );
+  const weeklyScoreTrend = inputs.weeklyScoreHistory ? computeWeeklyScoreTrend(inputs.weeklyScoreHistory) : null;
+
+  const metrics: DailySnapshotMetric[] = metricDefinitions.map((definition) => {
+    const trend = trendFindings.find((finding) => finding.metricKey === definition.key);
+    return {
+      key: definition.key,
+      label: definition.label,
+      unit: definition.unit ?? null,
+      target: metricDailyTargets[definition.key] ?? null,
+      todayValue: resolveMetricValue(inputs.entry, definition.key),
+      average7d: trend?.average7d ?? 0,
+      average28d: trend?.average28d ?? 0,
+      delta: trend?.delta ?? 0,
+      direction: trend?.direction ?? "flat"
+    };
+  });
+
+  const principles: DailySnapshotPrinciple[] = principleDefinitions.map((definition) => {
+    const streak = streakFindings.find((finding) => finding.principleKey === definition.key);
+    return {
+      key: definition.key,
+      label: definition.label,
+      timing: definition.timing,
+      todayValue: inputs.entry.principleChecks[definition.key],
+      currentStreak: streak?.currentStreak ?? 0,
+      longestStreak: streak?.longestStreak ?? 0,
+      daysSinceLastTrue: streak?.daysSinceLastTrue ?? null,
+      rate28d: streak?.rate28d ?? 0
+    };
+  });
+
+  const inboxBacklogFinding = gtdHealthFindings.find((finding) => finding.kind === "inbox_backlog");
+  const projectsWithoutNextActionFinding = gtdHealthFindings.find(
+    (finding) => finding.kind === "projects_without_next_action"
+  );
+  const staleNextActionsFinding = gtdHealthFindings.find((finding) => finding.kind === "stale_next_actions");
+  const agingWaitingForFinding = gtdHealthFindings.find((finding) => finding.kind === "aging_waiting_for");
+  const overdueDeadlinesFinding = gtdHealthFindings.find((finding) => finding.kind === "overdue_deadlines");
+  const scheduledVsCompletedFinding = gtdHealthFindings.find(
+    (finding) => finding.kind === "scheduled_vs_completed_ratio"
+  );
+  const projectTitles = projectTitleById(inputs.projects);
+
+  const gtd: DailySnapshotGtd = {
+    inboxBacklog: inboxBacklogFinding?.value ?? 0,
+    projectsWithoutNextAction: projectsWithoutNextActionFinding?.value ?? 0,
+    projectsWithoutNextActionSample: (projectsWithoutNextActionFinding?.projectIds ?? []).slice(0, 3).map((id) => ({
+      id,
+      ...(includeStructure ? { title: projectTitles.get(id) ?? id } : {})
+    })),
+    staleNextActions: staleNextActionsFinding?.value ?? 0,
+    agingWaitingFor: agingWaitingForFinding?.value ?? 0,
+    overdueDeadlines: overdueDeadlinesFinding?.value ?? 0,
+    scheduledVsCompletedRatio: scheduledVsCompletedFinding?.value ?? 0
+  };
+
+  const focusTotalsFinding = focusFindings.find((finding) => finding.kind === "focus_totals");
+  const taskConcentrationFinding = focusFindings.find((finding) => finding.kind === "task_concentration");
+  const topTaskSummary = inputs.pomodoroTaskSummaries.reduce<PomodoroTaskSummary | null>((top, summary) => {
+    if (!top || summary.totalSeconds > top.totalSeconds) {
+      return summary;
+    }
+    return top;
+  }, null);
+  const totalFocusSeconds = inputs.pomodoroTaskSummaries.reduce((sum, summary) => sum + summary.totalSeconds, 0);
+
+  const pomodoro: DailySnapshotPomodoro = {
+    completedFocusSessionCount: focusTotalsFinding?.value ?? inputs.completedFocusSessionCount,
+    totalFocusMinutes: Math.round(totalFocusSeconds / 60),
+    taskConcentration: taskConcentrationFinding?.value ?? null,
+    topTask: topTaskSummary
+      ? {
+          taskId: topTaskSummary.taskId,
+          ...(includeStructure ? { title: topTaskSummary.taskTitle } : {})
+        }
+      : null
+  };
+
+  const rescueTime: DailySnapshotRescueTime = {
+    configured: inputs.rescuetimeConfigured,
+    productivityPulseWeekToDate: inputs.productivityPulseWeekToDate
+  };
+
+  const disciplineShortWindow = entriesInTrailingWindow(ordered, inputs.date, TREND_SHORT_WINDOW_DAYS);
+  const disciplineLongWindow = entriesInTrailingWindow(ordered, inputs.date, TREND_LONG_WINDOW_DAYS);
+  const history: DailySnapshotHistory = {
+    daysConsidered: disciplineLongWindow.length,
+    disciplineAverage7d: average(disciplineShortWindow.map((entry) => computeDisciplineScore(entry))),
+    disciplineAverage28d: average(disciplineLongWindow.map((entry) => computeDisciplineScore(entry)))
+  };
+
+  const findings: Finding[] = [
+    ...streakFindings,
+    ...trendFindings,
+    ...correlationFindings,
+    ...anomalyFindings,
+    ...gtdHealthFindings,
+    ...focusFindings,
+    ...(weeklyScoreTrend ? [weeklyScoreTrend] : [])
+  ];
+
+  return {
+    surface: "daily",
+    scope,
+    date: inputs.date,
+    status: inputs.entry.status,
+    metrics,
+    principles,
+    ...(includeFreeText
+      ? {
+          notes: {
+            morningIntention: inputs.entry.morningIntention,
+            nightReflection: inputs.entry.nightReflection,
+            tomorrowFocus: inputs.entry.tomorrowFocus
+          }
+        }
+      : {}),
+    gtd,
+    pomodoro,
+    rescueTime,
+    history,
+    weeklyScoreTrend,
+    findings
+  };
+};

--- a/src/lib/ai/context/preview.test.ts
+++ b/src/lib/ai/context/preview.test.ts
@@ -1,6 +1,6 @@
 import { createEmptyDailyEntry, updateNote } from "../../../domain/daily-entry";
 import { MemoryRepository } from "../../storage/memory-repository";
-import { previewPayload } from "./preview";
+import { previewPayload, resolveProductivityPulse } from "./preview";
 
 describe("previewPayload", () => {
   it("renders the exact snapshot that would be sent for a given scope, from real repository data", async () => {
@@ -40,5 +40,38 @@ describe("previewPayload", () => {
     await expect(
       previewPayload(repository, "full", { surface: "weekly" as never })
     ).rejects.toThrow();
+  });
+});
+
+describe("resolveProductivityPulse", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("reports unconfigured with no error when RescueTime has no API key", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const result = await resolveProductivityPulse(repository, "2026-02-01");
+
+    expect(result.configured).toBe(false);
+    expect(result.pulseWeekToDate).toBeNull();
+    expect(result.fetchError).toBeUndefined();
+  });
+
+  it("surfaces fetchError (rather than pretending 'no data this week') when RescueTime is configured but the request fails", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+    await repository.saveSettings({ ...(await repository.getSettings()), rescuetimeApiKey: "rt-test-key" });
+    globalThis.fetch = vi.fn(async () => new Response("Unauthorized", { status: 401 })) as typeof fetch;
+
+    const result = await resolveProductivityPulse(repository, "2026-02-01");
+
+    expect(result.configured).toBe(true);
+    expect(result.pulseWeekToDate).toBeNull();
+    expect(result.fetchError).toBeDefined();
+    expect(result.fetchError).toContain("401");
   });
 });

--- a/src/lib/ai/context/preview.test.ts
+++ b/src/lib/ai/context/preview.test.ts
@@ -1,0 +1,44 @@
+import { createEmptyDailyEntry, updateNote } from "../../../domain/daily-entry";
+import { MemoryRepository } from "../../storage/memory-repository";
+import { previewPayload } from "./preview";
+
+describe("previewPayload", () => {
+  it("renders the exact snapshot that would be sent for a given scope, from real repository data", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    const date = "2026-02-01";
+    let entry = createEmptyDailyEntry(date);
+    entry = updateNote(entry, "morningIntention", "Texte libre du jour.");
+    await repository.saveDailyEntry(entry);
+    await repository.saveProject({
+      id: "project:demo",
+      title: "Projet demo",
+      status: "active",
+      statusChangedAt: new Date().toISOString(),
+      notes: "",
+      contextIds: [],
+      source: "manual",
+      sourceExternalId: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    });
+
+    const metricsSnapshot = await previewPayload(repository, "metrics", { date });
+    const fullSnapshot = await previewPayload(repository, "full", { date });
+
+    expect(metricsSnapshot.notes).toBeUndefined();
+    expect(fullSnapshot.notes?.morningIntention).toBe("Texte libre du jour.");
+    expect(metricsSnapshot.gtd.projectsWithoutNextAction).toBe(1);
+    expect(metricsSnapshot.rescueTime.configured).toBe(false);
+  });
+
+  it("rejects an unsupported surface", async () => {
+    const repository = new MemoryRepository();
+    await repository.initialize();
+
+    await expect(
+      previewPayload(repository, "full", { surface: "weekly" as never })
+    ).rejects.toThrow();
+  });
+});

--- a/src/lib/ai/context/preview.ts
+++ b/src/lib/ai/context/preview.ts
@@ -1,0 +1,98 @@
+import { createEmptyDailyEntry } from "../../../domain/daily-entry";
+import type { AiPayloadScope } from "../../../domain/types";
+import { getTodayDate } from "../../date";
+import { getWeekStartSunday } from "../../gtd/shared";
+import { RescueTimeGoalsService } from "../../rescuetime/rescuetime-goals-service";
+import type { AppRepository } from "../../storage/repository";
+import { buildDailySnapshot, type DailySnapshot } from "./daily-snapshot";
+import type { Surface } from "./types";
+
+export interface PreviewPayloadOptions {
+  surface?: Surface;
+  /** Local `YYYY-MM-DD` date to build the snapshot for. Defaults to today. */
+  date?: string;
+  /** ISO instant used as "now". Defaults to the current time. */
+  now?: string;
+  /**
+   * Pre-resolved RescueTime pulse to reuse across multiple `previewPayload` calls (e.g. one per
+   * scope) instead of each call independently fetching it. Defaults to resolving it internally.
+   */
+  productivityPulse?: ResolvedProductivityPulse;
+}
+
+export interface ResolvedProductivityPulse {
+  configured: boolean;
+  pulseWeekToDate: number | null;
+}
+
+/**
+ * Resolves the RescueTime week-to-date productivity pulse (or `null` when RescueTime isn't
+ * configured) once, so callers building previews for multiple scopes can share a single result
+ * instead of each scope triggering its own live RescueTime request.
+ */
+export const resolveProductivityPulse = async (
+  repository: AppRepository,
+  date: string
+): Promise<ResolvedProductivityPulse> => {
+  const settings = await repository.getSettings();
+  const configured = settings.rescuetimeApiKey.trim().length > 0;
+
+  if (!configured) {
+    return { configured, pulseWeekToDate: null };
+  }
+
+  const goalsService = new RescueTimeGoalsService(repository);
+  const pulseSnapshot = await goalsService.computeProductivityPulse(getWeekStartSunday(date));
+  return { configured, pulseWeekToDate: pulseSnapshot.pulse };
+};
+
+/**
+ * Renders the exact snapshot that would be sent to the model for a given scope, built from
+ * real repository data (spec `ai-integration-v2.md` §5). Exposed in Settings behind the
+ * existing debug affordance so a user can see exactly what each scope would send.
+ */
+export const previewPayload = async (
+  repository: AppRepository,
+  scope: AiPayloadScope,
+  options: PreviewPayloadOptions = {}
+): Promise<DailySnapshot> => {
+  const surface = options.surface ?? "daily";
+  if (surface !== "daily") {
+    throw new Error(`Surface non supportee pour l'aperçu IA: ${surface}`);
+  }
+
+  const date = options.date ?? getTodayDate();
+  const now = options.now ?? new Date().toISOString();
+
+  const [entry, historyEntries, tasks, projects, pomodoroTaskSummaries, dailyPomodoroStats, resolvedPulse] =
+    await Promise.all([
+      repository.getDailyEntry(date),
+      repository.listDailyEntries(28),
+      repository.listTasks({ includeCompleted: true }),
+      repository.listProjects(),
+      repository.listPomodoroTaskSummaries(date, now),
+      repository.computeDailyPomodoroStats(date),
+      options.productivityPulse ?? resolveProductivityPulse(repository, date)
+    ]);
+
+  const resolvedEntry = entry ?? createEmptyDailyEntry(date);
+  const historyEntriesWithToday = historyEntries.some((item) => item.date === date)
+    ? historyEntries
+    : [...historyEntries, resolvedEntry];
+
+  return buildDailySnapshot(
+    {
+      date,
+      entry: resolvedEntry,
+      historyEntries: historyEntriesWithToday,
+      tasks,
+      projects,
+      pomodoroTaskSummaries,
+      completedFocusSessionCount: dailyPomodoroStats.completedFocusSessions,
+      productivityPulseWeekToDate: resolvedPulse.pulseWeekToDate,
+      rescuetimeConfigured: resolvedPulse.configured,
+      now
+    },
+    scope
+  );
+};

--- a/src/lib/ai/context/preview.ts
+++ b/src/lib/ai/context/preview.ts
@@ -7,6 +7,16 @@ import type { AppRepository } from "../../storage/repository";
 import { buildDailySnapshot, type DailySnapshot } from "./daily-snapshot";
 import type { Surface } from "./types";
 
+/**
+ * How much daily-entry history to load for the insight engine. `computeStreakFindings`'s
+ * `longestStreak`/`daysSinceLastTrue` and `computeCorrelationFindings` are documented as
+ * covering "the whole provided history" — a small cap silently truncates that history and
+ * makes "long ago" indistinguishable from "never" (e.g. `daysSinceLastTrue: null`). These are
+ * local SQLite reads, so loading half a year of entries is cheap; 180 comfortably covers a
+ * year of quarterly review cycles without being unbounded.
+ */
+const INSIGHT_HISTORY_LOOKBACK_DAYS = 180;
+
 export interface PreviewPayloadOptions {
   surface?: Surface;
   /** Local `YYYY-MM-DD` date to build the snapshot for. Defaults to today. */
@@ -23,6 +33,8 @@ export interface PreviewPayloadOptions {
 export interface ResolvedProductivityPulse {
   configured: boolean;
   pulseWeekToDate: number | null;
+  /** Set when RescueTime is configured but the request failed (bad key, expired key, no connectivity) — distinguishes a fetch failure from "no data this week" (`pulseWeekToDate: null` with no error). */
+  fetchError?: string;
 }
 
 /**
@@ -43,7 +55,7 @@ export const resolveProductivityPulse = async (
 
   const goalsService = new RescueTimeGoalsService(repository);
   const pulseSnapshot = await goalsService.computeProductivityPulse(getWeekStartSunday(date));
-  return { configured, pulseWeekToDate: pulseSnapshot.pulse };
+  return { configured, pulseWeekToDate: pulseSnapshot.pulse, fetchError: pulseSnapshot.fetchError };
 };
 
 /**
@@ -67,7 +79,7 @@ export const previewPayload = async (
   const [entry, historyEntries, tasks, projects, pomodoroTaskSummaries, dailyPomodoroStats, resolvedPulse] =
     await Promise.all([
       repository.getDailyEntry(date),
-      repository.listDailyEntries(28),
+      repository.listDailyEntries(INSIGHT_HISTORY_LOOKBACK_DAYS),
       repository.listTasks({ includeCompleted: true }),
       repository.listProjects(),
       repository.listPomodoroTaskSummaries(date, now),

--- a/src/lib/ai/context/types.ts
+++ b/src/lib/ai/context/types.ts
@@ -1,0 +1,7 @@
+/**
+ * AI context surfaces (spec `ai-integration-v2.md` §5). Weekly, monthly, annual, GTD and
+ * Pomodoro surfaces are later phases; `"daily"` is the only member today. Keep this a
+ * union so a later phase can extend it without a breaking change to callers that already
+ * match on `Surface`.
+ */
+export type Surface = "daily";

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsPage } from "./SettingsPage";
+import { renderWithApp } from "../test/test-utils";
+
+describe("SettingsPage AI payload preview", () => {
+  it("hides the debug payload preview when debug mode is off", async () => {
+    await renderWithApp(<SettingsPage />, { contextOverrides: { debugEnabled: false } });
+
+    expect(screen.queryByText("Apercu du payload IA (debug)")).not.toBeInTheDocument();
+  });
+
+  it("renders the three scoped payload previews when debug mode is on, redacting free text at the metrics scope", async () => {
+    const user = userEvent.setup();
+    await renderWithApp(<SettingsPage />, { contextOverrides: { debugEnabled: true } });
+
+    expect(screen.getByText("Apercu du payload IA (debug)")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Calculer l'apercu pour les 3 portees" }));
+
+    const findSummary = (label: string) =>
+      screen.findAllByText(label).then((matches) => matches.find((node) => node.tagName === "SUMMARY")!);
+
+    const metricsSummary = await findSummary("metrics");
+    expect(metricsSummary).toBeInTheDocument();
+    expect(await findSummary("metrics_and_structure")).toBeInTheDocument();
+    expect((await findSummary("full")).tagName).toBe("SUMMARY");
+
+    const metricsPre = metricsSummary.parentElement?.querySelector("pre");
+    expect(metricsPre?.textContent).not.toContain("\"notes\"");
+
+    const fullSummary = await findSummary("full");
+    const fullPre = fullSummary.parentElement?.querySelector("pre");
+    expect(fullPre?.textContent).toContain("\"notes\"");
+  });
+});

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -37,6 +37,7 @@ export const SettingsPage = () => {
   const [payloadPreviews, setPayloadPreviews] = useState<Record<AiPayloadScope, string> | null>(null);
   const [loadingPayloadPreviews, setLoadingPayloadPreviews] = useState(false);
   const [payloadPreviewError, setPayloadPreviewError] = useState("");
+  const [payloadPreviewPulseWarning, setPayloadPreviewPulseWarning] = useState("");
 
   useEffect(() => {
     setDraftSettings(settings);
@@ -209,6 +210,7 @@ export const SettingsPage = () => {
           subtitle="Rendu exact du contexte quotidien envoye a l'IA pour chaque portee, construit a partir des donnees reelles."
         >
           {payloadPreviewError ? <div className="banner">{payloadPreviewError}</div> : null}
+          {payloadPreviewPulseWarning ? <div className="banner">{payloadPreviewPulseWarning}</div> : null}
 
           <div className="form-actions">
             <button
@@ -218,10 +220,16 @@ export const SettingsPage = () => {
               onClick={async () => {
                 setLoadingPayloadPreviews(true);
                 setPayloadPreviewError("");
+                setPayloadPreviewPulseWarning("");
 
                 try {
                   const date = getTodayDate();
                   const productivityPulse = await resolveProductivityPulse(repository, date);
+                  if (productivityPulse.fetchError) {
+                    setPayloadPreviewPulseWarning(
+                      `Pulse RescueTime indisponible pour cet apercu (${productivityPulse.fetchError}). L'apercu ci-dessous affichera "pas de donnee" a la place.`
+                    );
+                  }
                   const entries = await Promise.all(
                     payloadScopes.map(async (scope) => {
                       const snapshot = await previewPayload(repository, scope.value, { date, productivityPulse });

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
 import { defaultAppSettings } from "../domain/daily-entry";
-import type { AppSettings } from "../domain/types";
+import type { AiPayloadScope, AppSettings } from "../domain/types";
 import { useAppContext } from "../app/app-context";
 import { SectionCard } from "../components/SectionCard";
 import initialGoogleTasksExport from "../../Tasks.json";
-import { formatDateTimeShort } from "../lib/date";
+import { formatDateTimeShort, getTodayDate } from "../lib/date";
 import type { StorageInfo } from "../lib/storage/repository";
 import { RescueTimeGoalsService } from "../lib/rescuetime/rescuetime-goals-service";
+import { previewPayload, resolveProductivityPulse } from "../lib/ai/context/preview";
+
+const payloadScopes: Array<{ value: AiPayloadScope; label: string }> = [
+  { value: "metrics", label: "metrics" },
+  { value: "metrics_and_structure", label: "metrics_and_structure" },
+  { value: "full", label: "full" }
+];
 
 export const SettingsPage = () => {
   const { repository, settings, saveSettings, debugEnabled, setDebugEnabled, browserPreview } = useAppContext();
@@ -27,6 +34,9 @@ export const SettingsPage = () => {
   const [gtdOverview, setGtdOverview] = useState<{ taskCount: number; projectCount: number; contextCount: number } | null>(
     null
   );
+  const [payloadPreviews, setPayloadPreviews] = useState<Record<AiPayloadScope, string> | null>(null);
+  const [loadingPayloadPreviews, setLoadingPayloadPreviews] = useState(false);
+  const [payloadPreviewError, setPayloadPreviewError] = useState("");
 
   useEffect(() => {
     setDraftSettings(settings);
@@ -159,6 +169,25 @@ export const SettingsPage = () => {
             />
           </label>
 
+          <label>
+            <span>Portee du payload envoye a l&apos;IA</span>
+            <select
+              value={draftSettings.aiPayloadScope}
+              onChange={(event) =>
+                setDraftSettings((current) => ({
+                  ...current,
+                  aiPayloadScope: event.target.value as AiPayloadScope
+                }))
+              }
+            >
+              {payloadScopes.map((scope) => (
+                <option key={scope.value} value={scope.value}>
+                  {scope.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
           <div className="form-actions">
             <button className="button button--primary" type="submit" disabled={savingSettings}>
               {savingSettings ? "Enregistrement..." : "Enregistrer les parametres"}
@@ -173,6 +202,58 @@ export const SettingsPage = () => {
           </div>
         </form>
       </SectionCard>
+
+      {debugEnabled ? (
+        <SectionCard
+          title="Apercu du payload IA (debug)"
+          subtitle="Rendu exact du contexte quotidien envoye a l'IA pour chaque portee, construit a partir des donnees reelles."
+        >
+          {payloadPreviewError ? <div className="banner">{payloadPreviewError}</div> : null}
+
+          <div className="form-actions">
+            <button
+              className="button button--primary"
+              type="button"
+              disabled={loadingPayloadPreviews}
+              onClick={async () => {
+                setLoadingPayloadPreviews(true);
+                setPayloadPreviewError("");
+
+                try {
+                  const date = getTodayDate();
+                  const productivityPulse = await resolveProductivityPulse(repository, date);
+                  const entries = await Promise.all(
+                    payloadScopes.map(async (scope) => {
+                      const snapshot = await previewPayload(repository, scope.value, { date, productivityPulse });
+                      return [scope.value, JSON.stringify(snapshot, null, 2)] as const;
+                    })
+                  );
+                  setPayloadPreviews(Object.fromEntries(entries) as Record<AiPayloadScope, string>);
+                } catch (error) {
+                  setPayloadPreviewError(
+                    error instanceof Error ? error.message : "Echec du calcul de l'apercu du payload IA."
+                  );
+                } finally {
+                  setLoadingPayloadPreviews(false);
+                }
+              }}
+            >
+              {loadingPayloadPreviews ? "Calcul en cours..." : "Calculer l'apercu pour les 3 portees"}
+            </button>
+          </div>
+
+          {payloadPreviews ? (
+            <div className="payload-preview">
+              {payloadScopes.map((scope) => (
+                <details key={scope.value}>
+                  <summary>{scope.label}</summary>
+                  <pre>{payloadPreviews[scope.value]}</pre>
+                </details>
+              ))}
+            </div>
+          ) : null}
+        </SectionCard>
+      ) : null}
 
       <SectionCard
         title="RescueTime"

--- a/src/styles.css
+++ b/src/styles.css
@@ -296,6 +296,23 @@ a {
   overflow-wrap: anywhere;
 }
 
+.payload-preview {
+  display: grid;
+  gap: 10px;
+}
+
+.payload-preview pre {
+  margin: 8px 0 0;
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  max-height: 360px;
+  overflow: auto;
+}
+
 .summary-strip {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
## Summary

Implements Phase 0 of [`specs/ai-integration-v2.md`](specs/ai-integration-v2.md) (§11 phasing table): *"Insight engine (incl. `movement.ts`), context builder, redaction, payload preview — local coach becomes substantive; zero network change."*

- New `src/domain/insights/` — pure, fixture-tested modules: `streaks`, `trends`, `correlations`, `gtd-health`, `focus`, `anomalies`, `movement`. No repository access; findings share a common `{ id, severity, evidenceWindow, sampleSize, value }` shape, respect a minimum-sample floor, and use observation-only ("associée à") language never causal claims.
- New `src/lib/ai/context/` — a context builder for the daily surface, joining insight findings with `definitions.ts` for labelled/unit/target/delta metrics and labelled/timed/streaked principles. Redaction is centralized via a new `aiPayloadScope` setting (`metrics` / `metrics_and_structure` / `full`, default `full`), and `previewPayload()` renders the exact bytes for each scope.
- A debug-only payload-preview panel in Settings (gated on the existing debug toggle) shows all three scopes' rendered JSON, resolving the RescueTime pulse once and reusing it across scopes rather than fetching per scope.
- Docs updated: `docs/ai-settings-and-privacy.md` (new setting + preview panel) and `docs/log.md`.

**Explicitly out of scope** (left untouched, per the spec's own phase boundaries): `coach-service.ts`, `openrouter-provider.ts`, `provider.ts`, `coach-input.ts`, `TodayPage.tsx` coach call sites, any SQLite migration, `ai_messages`/`ai_proposals`/`ai_memories`, pulse scheduling, and the S1–S5 structured-output schemas. This phase adds new, tested, currently-unwired foundations — the live AI request path is unchanged.

## Process

Built and reviewed via the develop-review loop: a Sonnet 5 developer implemented the phase, an independent Opus 5 reviewer read the actual diff (not a summary) and ran tests/build itself. Round 1 found 6 real defects — non-calendar-aware streaks, a fabricated single-week trend baseline, non-conventional date arithmetic, a debug preview that fired 3 live RescueTime HTTP requests per click, a week-to-date RescueTime pulse mislabeled as same-day, and missing doc updates. All 6 were fixed and independently re-verified (including live tracing of the RescueTime call graph and DST-boundary date checks) before approval.

## Test plan

- [x] `npm run test` — 408/408 tests pass (7 unrelated collection failures are pre-existing stale `.claude/worktrees/*` checkouts missing `Tasks.json`, not part of this diff)
- [x] `npm run build` — `tsc --noEmit` + vite build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)